### PR TITLE
Add Featherless provider and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@
   <a href="">
     <img src="https://img.shields.io/static/v1?label=Anthropic&message=Claude&color=000000&logo=anthropic&style=flat" />
   </a>
+  <a href="./docs/featherless.md">
+    <img src="https://img.shields.io/static/v1?label=Featherless&message=Open%20Models&color=6D28D9&style=flat" />
+  </a>
 </p>
 
 ---
@@ -60,6 +63,7 @@ It began as a prototype of a web app that uses [GPT-4](https://openai.com/resear
 | GM GPT-3.5 Physics Fine Tuned | Fine-tuned GPT-3.5 model trained to generate Physics animations           | GPT-3.5                    | ✅    |
 | GM Claude Sonnet              | Claude Sonnet 3 model from Sonnet adapted with our custom System Prompt   | claude-3-sonnet-20240229   | ✅    |
 | GM Claude Sonnet 3.5          | Claude Sonnet 3.5 model from Sonnet adapted with our custom System Prompt | claude-3-5-sonnet-20240620 | ✅    |
+| GM Featherless Open Models    | OpenAI-compatible access to hosted open-weight models via Featherless     | Qwen, DeepSeek, CodeLlama, etc. | ✅ |
 | GM Qwen 2.5 Coder 7B          | Open-source model fine-tuned with SFT + DPO + GRPO pipeline              | Qwen2.5-Coder-7B-Instruct | 🚧    |
 | GM DeepSeek Coder V2 Lite      | Open-source model fine-tuned with SFT + DPO + GRPO pipeline              | DeepSeek-Coder-V2-Lite     | 🚧    |
 | GM CodeLlama 7B                | Open-source model fine-tuned with SFT + DPO + GRPO pipeline              | CodeLlama-7b-Instruct      | 🚧    |
@@ -122,6 +126,16 @@ Or run a whole benchmark matrix from a manifest:
 cd training
 python -m benchmarks.matrix --manifest benchmarks/manifests/open_source_core_v1.json --dry-run
 ```
+
+You can also benchmark hosted open-weight models through Featherless:
+
+```bash
+export FEATHERLESS_API_KEY="your-featherless-key"
+cd training
+python -m benchmarks.matrix --manifest benchmarks/manifests/featherless_core_v1.json --only qwen2.5-coder-7b-instruct-featherless
+```
+
+See [`docs/featherless.md`](./docs/featherless.md) for API usage, smoke tests, and the full Featherless benchmark workflow.
 
 ## ✨ Sponsors
 

--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -19,6 +19,8 @@ import uuid
 
 chat_generation_bp = Blueprint("chat_generation", __name__)
 
+FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1"
+
 
 animo_functions = {
     "openai": [
@@ -135,7 +137,8 @@ def generate_code_chat():
     ENGINE_DEFAULTS = {
         "openai": "gpt-4o",
         "anthropic": "claude-35-sonnet",
-        "deepseek": "r1"
+        "deepseek": "r1",
+        "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
     }
 
     # Validate and set the model based on engine
@@ -150,10 +153,11 @@ def generate_code_chat():
     VALID_MODELS = {
         "openai": ["gpt-4o", "o1-mini"],
         "anthropic": ["claude-35-sonnet"],
-        "deepseek": ["r1"]
+        "deepseek": ["r1"],
+        "featherless": None,
     }
 
-    if model not in VALID_MODELS[engine]:
+    if VALID_MODELS[engine] is not None and model not in VALID_MODELS[engine]:
         return jsonify({
             "error": f"Invalid model '{model}' for engine '{engine}'. Valid models are: {', '.join(VALID_MODELS[engine])}"
         }), 400
@@ -323,6 +327,56 @@ That message should appear after the code, as the last message of the conversati
 """
 
     messages.insert(0, {"role": "system", "content": general_system_prompt})
+
+    if engine == "featherless":
+        api_key = os.environ.get("FEATHERLESS_API_KEY")
+        if not api_key:
+            return jsonify({"error": "FEATHERLESS_API_KEY is required when engine='featherless'"}), 500
+
+        client = openai.OpenAI(base_url=FEATHERLESS_BASE_URL, api_key=api_key)
+        featherless_system_prompt = """You are an assistant that generates complete Manim animation code.
+
+Rules:
+1. Always use GenScene as the class name.
+2. Always use self.play() to play animations.
+3. Always start with `from manim import *`.
+4. Output only Python code unless the user asks a conceptual question.
+5. The code must be complete and runnable."""
+        messages[0] = {"role": "system", "content": featherless_system_prompt}
+
+        def generate():
+            try:
+                stream = client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    temperature=data.get("temperature", 0.2),
+                    max_tokens=data.get("maxTokens", 2048),
+                    stream=True,
+                )
+                for chunk in stream:
+                    content = chunk.choices[0].delta.content
+                    if not content:
+                        continue
+                    if is_for_platform:
+                        text_obj = json.dumps({"type": "text", "text": content})
+                        yield f"{text_obj}\n"
+                    else:
+                        yield content
+            except Exception as e:
+                error_message = str(e)
+                if is_for_platform:
+                    yield f"{json.dumps({'type': 'error', 'text': error_message})}\n"
+                else:
+                    yield f"Error: {error_message}"
+
+        response = Response(
+            stream_with_context(generate()),
+            content_type="text/plain; charset=utf-8",
+        )
+        if is_for_platform:
+            response.headers['Transfer-Encoding'] = 'chunked'
+            response.headers['x-vercel-ai-data-stream'] = 'v1'
+        return response
 
     if engine == "anthropic":
         client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -5,11 +5,41 @@ from openai import OpenAI
 
 code_generation_bp = Blueprint('code_generation', __name__)
 
+
+ENGINE_DEFAULTS = {
+    "openai": "gpt-4o",
+    "anthropic": "claude-3-5-sonnet-20241022",
+    "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
+}
+
+FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1"
+
+
+def get_openai_compatible_client(engine: str) -> OpenAI:
+    if engine == "featherless":
+        api_key = os.getenv("FEATHERLESS_API_KEY")
+        if not api_key:
+            raise ValueError("FEATHERLESS_API_KEY is required when engine='featherless'")
+        return OpenAI(base_url=FEATHERLESS_BASE_URL, api_key=api_key)
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY is required when engine='openai'")
+    return OpenAI(api_key=api_key)
+
+
 @code_generation_bp.route('/v1/code/generation', methods=['POST'])
 def generate_code():
     body = request.json
     prompt_content = body.get("prompt", "")
-    model = body.get("model", "gpt-4o")
+    engine = body.get("engine", "openai")
+
+    if engine not in ENGINE_DEFAULTS:
+        return jsonify({
+            "error": f"Invalid engine. Must be one of: {', '.join(ENGINE_DEFAULTS.keys())}"
+        }), 400
+
+    model = body.get("model", ENGINE_DEFAULTS[engine])
 
     general_system_prompt = """
 You are an assistant that knows about Manim. Manim is a mathematical animation engine that is used to create videos programmatically.
@@ -33,7 +63,7 @@ def construct(self):
 4. Do not explain the code, only the code.
     """
 
-    if model.startswith("claude-"):
+    if engine == "anthropic" or model.startswith("claude-"):
         client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
         messages = [{"role": "user", "content": prompt_content}]
         try:
@@ -54,13 +84,13 @@ def construct(self):
             return jsonify({"error": str(e)}), 500
 
     else:
-        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         messages = [
             {"role": "system", "content": general_system_prompt},
             {"role": "user", "content": prompt_content},
         ]
 
         try:
+            client = get_openai_compatible_client(engine)
             response = client.chat.completions.create(
                 model=model,
                 messages=messages,

--- a/docs/featherless.md
+++ b/docs/featherless.md
@@ -1,0 +1,139 @@
+# Generative Manim with Featherless
+
+Generative Manim can use [Featherless](https://featherless.ai) as an OpenAI-compatible provider for open-weight models. This is useful for two workflows:
+
+1. Generate Manim code from prompts through the API.
+2. Benchmark hosted open models with the render-based Manim verifier.
+
+## API Setup
+
+Create a Featherless API key from your account dashboard, then export it:
+
+```bash
+export FEATHERLESS_API_KEY="your-featherless-key"
+```
+
+Run the API:
+
+```bash
+python run.py
+```
+
+Generate Manim code with a Featherless model:
+
+```bash
+curl -X POST http://127.0.0.1:8080/v1/code/generation \
+  -H "Content-Type: application/json" \
+  -d '{
+    "engine": "featherless",
+    "model": "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "prompt": "Create a Manim animation that explains the Pythagorean theorem with a right triangle and colored squares."
+  }'
+```
+
+The chat endpoint also accepts `engine: "featherless"`:
+
+```bash
+curl -N -X POST http://127.0.0.1:8080/v1/chat/generation \
+  -H "Content-Type: application/json" \
+  -d '{
+    "engine": "featherless",
+    "model": "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Create a Manim scene that animates a sine wave being drawn over axes."
+      }
+    ]
+  }'
+```
+
+## Benchmark Hosted Models
+
+The benchmark path evaluates generated code by rendering it with Manim, then reporting render success, required Manim patterns, animation-count compliance, and pass@k.
+
+Set your key:
+
+```bash
+export FEATHERLESS_API_KEY="your-featherless-key"
+```
+
+Dry-run the Featherless benchmark matrix:
+
+```bash
+cd training
+python -m benchmarks.matrix \
+  --manifest benchmarks/manifests/featherless_core_v1.json \
+  --dry-run
+```
+
+Run one model first:
+
+```bash
+cd training
+python -m benchmarks.matrix \
+  --manifest benchmarks/manifests/featherless_core_v1.json \
+  --only qwen2.5-coder-7b-instruct-featherless
+```
+
+Run the full matrix:
+
+```bash
+cd training
+python -m benchmarks.matrix \
+  --manifest benchmarks/manifests/featherless_core_v1.json
+```
+
+Results are written to:
+
+```text
+training/outputs/benchmarks/featherless_core_v1/
+```
+
+## Lower-Cost Smoke Test
+
+To conserve tokens, generate responses for only a few benchmark prompts:
+
+```bash
+cd training
+python -m benchmarks.run export \
+  --suite benchmarks/tasks/core_v1.jsonl \
+  --output ./outputs/benchmarks/featherless_smoke_prompts.jsonl
+
+python -m eval.generate_remote_responses \
+  --provider featherless \
+  --model Qwen/Qwen2.5-Coder-7B-Instruct \
+  --test-path ./outputs/benchmarks/featherless_smoke_prompts.jsonl \
+  --output ./outputs/benchmarks/featherless_smoke_responses.jsonl \
+  --samples-per-prompt 1 \
+  --temperature 0.2 \
+  --limit 3
+```
+
+Then evaluate those responses:
+
+```bash
+python -m benchmarks.run evaluate \
+  --suite benchmarks/tasks/core_v1.jsonl \
+  --responses ./outputs/benchmarks/featherless_smoke_responses.jsonl \
+  --output-dir ./outputs/benchmarks/featherless_smoke \
+  --model-name qwen2.5-coder-7b-instruct-featherless \
+  --run-name smoke \
+  --pass-k 1
+```
+
+Partial smoke runs will show missing tasks in the summary. Full benchmark runs should use the matrix manifest.
+
+## Demo Prompts
+
+Good demo prompts for visual examples:
+
+- `Create a Manim animation that explains the Pythagorean theorem with a right triangle and colored squares.`
+- `Create a scene where a sine wave is drawn over axes while a dot moves along the curve.`
+- `Animate gradient descent on a simple parabola, showing the point stepping toward the minimum.`
+
+## Notes
+
+- Featherless is OpenAI-compatible, so the integration uses the OpenAI Python SDK with `base_url="https://api.featherless.ai/v1"`.
+- Hosted open models vary in instruction following. The benchmark is designed to make that variation visible through render success and pass@k.
+- For public results, prefer `samples_per_prompt >= 3` so pass@k is meaningful.

--- a/training/benchmarks/manifests/featherless_core_v1.json
+++ b/training/benchmarks/manifests/featherless_core_v1.json
@@ -13,12 +13,6 @@
       "provider": "featherless"
     },
     {
-      "model": "deepseek-coder-v2-lite-instruct-featherless",
-      "model_id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
-      "run_name": "featherless",
-      "provider": "featherless"
-    },
-    {
       "model": "codellama-7b-instruct-featherless",
       "model_id": "codellama/CodeLlama-7b-Instruct-hf",
       "run_name": "featherless",

--- a/training/benchmarks/manifests/featherless_core_v1.json
+++ b/training/benchmarks/manifests/featherless_core_v1.json
@@ -1,0 +1,28 @@
+{
+  "suite": "benchmarks/tasks/core_v1.jsonl",
+  "output_dir": "./outputs/benchmarks/featherless_core_v1",
+  "samples_per_prompt": 3,
+  "temperature": 0.7,
+  "pass_k": [1, 3],
+  "max_tokens": 2048,
+  "runs": [
+    {
+      "model": "qwen2.5-coder-7b-instruct-featherless",
+      "model_id": "Qwen/Qwen2.5-Coder-7B-Instruct",
+      "run_name": "featherless",
+      "provider": "featherless"
+    },
+    {
+      "model": "deepseek-coder-v2-lite-instruct-featherless",
+      "model_id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct",
+      "run_name": "featherless",
+      "provider": "featherless"
+    },
+    {
+      "model": "codellama-7b-instruct-featherless",
+      "model_id": "codellama/CodeLlama-7b-Instruct-hf",
+      "run_name": "featherless",
+      "provider": "featherless"
+    }
+  ]
+}

--- a/training/benchmarks/matrix.py
+++ b/training/benchmarks/matrix.py
@@ -100,40 +100,74 @@ def run_matrix(
 
     for run in selected_runs:
         model_name = run["model"]
+        model_id = run.get("model_id", model_name)
         run_name = run["run_name"]
         run_output_dir = output_dir / model_name / run_name
         if not dry_run:
             run_output_dir.mkdir(parents=True, exist_ok=True)
         responses_path = _resolve_path(run.get("responses_path"))
         checkpoint_path = _resolve_path(run.get("checkpoint"))
+        provider = run.get("provider")
 
         if responses_path is None:
-            if checkpoint_path is None:
+            if provider:
+                generate_command = [
+                    sys.executable,
+                    "-m",
+                    "eval.generate_remote_responses",
+                    "--provider",
+                    provider,
+                    "--model",
+                    model_id,
+                    "--test-path",
+                    str(prompts_path),
+                    "--output",
+                    str(run_output_dir / "responses.jsonl"),
+                    "--temperature",
+                    str(run.get("temperature", temperature)),
+                    "--samples-per-prompt",
+                    str(run.get("samples_per_prompt", samples_per_prompt)),
+                    "--max-tokens",
+                    str(run.get("max_tokens", manifest.get("max_tokens", 2048))),
+                ]
+                if run.get("base_url"):
+                    generate_command.extend(["--base-url", run["base_url"]])
+                if run.get("api_key_env"):
+                    generate_command.extend(["--api-key-env", run["api_key_env"]])
+                if run.get("limit") is not None:
+                    generate_command.extend(["--limit", str(run["limit"])])
+                effective_seed = run.get("seed", seed)
+                if effective_seed is not None:
+                    generate_command.extend(["--seed", str(effective_seed)])
+                _run_command(generate_command, dry_run=dry_run)
+                responses_path = run_output_dir / "responses.jsonl"
+            elif checkpoint_path is None:
                 raise ValueError(
-                    f"Run {run_name} must define either checkpoint or responses_path"
+                    f"Run {run_name} must define checkpoint, provider, or responses_path"
                 )
-            generate_command = [
-                sys.executable,
-                "-m",
-                "eval.generate_responses",
-                "--model",
-                model_name,
-                "--checkpoint",
-                str(checkpoint_path),
-                "--test-path",
-                str(prompts_path),
-                "--output",
-                str(run_output_dir / "responses.jsonl"),
-                "--temperature",
-                str(run.get("temperature", temperature)),
-                "--samples-per-prompt",
-                str(run.get("samples_per_prompt", samples_per_prompt)),
-            ]
-            effective_seed = run.get("seed", seed)
-            if effective_seed is not None:
-                generate_command.extend(["--seed", str(effective_seed)])
-            _run_command(generate_command, dry_run=dry_run)
-            responses_path = run_output_dir / "responses.jsonl"
+            else:
+                generate_command = [
+                    sys.executable,
+                    "-m",
+                    "eval.generate_responses",
+                    "--model",
+                    model_name,
+                    "--checkpoint",
+                    str(checkpoint_path),
+                    "--test-path",
+                    str(prompts_path),
+                    "--output",
+                    str(run_output_dir / "responses.jsonl"),
+                    "--temperature",
+                    str(run.get("temperature", temperature)),
+                    "--samples-per-prompt",
+                    str(run.get("samples_per_prompt", samples_per_prompt)),
+                ]
+                effective_seed = run.get("seed", seed)
+                if effective_seed is not None:
+                    generate_command.extend(["--seed", str(effective_seed)])
+                _run_command(generate_command, dry_run=dry_run)
+                responses_path = run_output_dir / "responses.jsonl"
         else:
             print(f"Using pre-generated responses for {model_name}/{run_name}: {responses_path}")
 

--- a/training/benchmarks/run.py
+++ b/training/benchmarks/run.py
@@ -89,6 +89,10 @@ def _parse_pass_k(pass_k: str) -> list[int]:
     return sorted(set(values))
 
 
+def _safe_name(value: str) -> str:
+    return value.replace("/", "__").replace(":", "__")
+
+
 def evaluate_suite(
     suite_path: str | Path,
     responses_path: str | Path,
@@ -281,9 +285,11 @@ def evaluate_suite(
         "categories": category_summary,
     }
 
-    results_path = output / f"{model_name}_{run_name}_{summary['suite']}_results.jsonl"
-    summary_path = output / f"{model_name}_{run_name}_{summary['suite']}_summary.json"
-    tasks_path = output / f"{model_name}_{run_name}_{summary['suite']}_tasks.jsonl"
+    safe_model_name = _safe_name(model_name)
+    safe_run_name = _safe_name(run_name)
+    results_path = output / f"{safe_model_name}_{safe_run_name}_{summary['suite']}_results.jsonl"
+    summary_path = output / f"{safe_model_name}_{safe_run_name}_{summary['suite']}_summary.json"
+    tasks_path = output / f"{safe_model_name}_{safe_run_name}_{summary['suite']}_tasks.jsonl"
 
     with open(results_path, "w") as f:
         for row in results:

--- a/training/eval/generate_remote_responses.py
+++ b/training/eval/generate_remote_responses.py
@@ -1,0 +1,174 @@
+"""Generate benchmark responses with OpenAI-compatible hosted providers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+from openai import OpenAI
+from tqdm import tqdm
+
+from utils.system_prompt import SYSTEM_PROMPT
+
+
+DEFAULT_TEST = Path(__file__).parent.parent / "data" / "outputs" / "test_prompts.jsonl"
+FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1"
+
+
+def _provider_defaults(provider: str) -> tuple[str | None, str]:
+    if provider == "featherless":
+        return FEATHERLESS_BASE_URL, "FEATHERLESS_API_KEY"
+    if provider == "openai":
+        return None, "OPENAI_API_KEY"
+    raise ValueError(f"Unsupported provider: {provider}")
+
+
+def _load_prompts(test_path: Path, limit: int | None = None) -> list[dict]:
+    prompts = []
+    with open(test_path) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            prompts.append(json.loads(line))
+            if limit is not None and len(prompts) >= limit:
+                break
+    return prompts
+
+
+def generate_remote_responses(
+    model: str,
+    provider: str = "featherless",
+    test_path: str | Path = DEFAULT_TEST,
+    output_path: str | Path | None = None,
+    base_url: str | None = None,
+    api_key_env: str | None = None,
+    max_tokens: int = 2048,
+    temperature: float = 0.2,
+    samples_per_prompt: int = 1,
+    seed: int | None = None,
+    limit: int | None = None,
+    max_retries: int = 3,
+    retry_delay: float = 4.0,
+) -> str:
+    """Generate responses for benchmark prompts using a hosted chat model."""
+    if samples_per_prompt < 1:
+        raise ValueError("samples_per_prompt must be >= 1")
+    if samples_per_prompt > 1 and temperature <= 0:
+        raise ValueError("temperature must be > 0 when samples_per_prompt > 1")
+
+    default_base_url, default_api_key_env = _provider_defaults(provider)
+    base_url = base_url if base_url is not None else default_base_url
+    api_key_env = api_key_env or default_api_key_env
+    api_key = os.getenv(api_key_env)
+    if not api_key:
+        raise ValueError(f"{api_key_env} is required for provider={provider}")
+
+    test_path = Path(test_path)
+    prompts = _load_prompts(test_path, limit=limit)
+
+    if output_path is None:
+        safe_model = model.replace("/", "__")
+        output_path = Path("outputs") / "remote" / provider / safe_model / "responses.jsonl"
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+
+    print(
+        f"Generating {samples_per_prompt} sample(s) for {len(prompts)} prompts "
+        f"with {provider}:{model}"
+    )
+
+    with open(output_path, "w") as f:
+        for row in tqdm(prompts, desc="Generating"):
+            prompt = row["prompt"]
+            messages = [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ]
+
+            for sample_index in range(samples_per_prompt):
+                request_payload = {
+                    "model": model,
+                    "messages": messages,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                }
+                if seed is not None:
+                    request_payload["seed"] = seed + sample_index
+
+                last_error = None
+                started_at = time.perf_counter()
+                for attempt in range(max_retries):
+                    try:
+                        response = client.chat.completions.create(**request_payload)
+                        latency = time.perf_counter() - started_at
+                        content = response.choices[0].message.content or ""
+                        payload = {
+                            "prompt": prompt,
+                            "response": content,
+                            "sample_index": sample_index,
+                            "provider": provider,
+                            "model": model,
+                            "latency_seconds": round(latency, 3),
+                        }
+                        for key in ("task_id", "category", "difficulty"):
+                            if key in row:
+                                payload[key] = row[key]
+                        f.write(json.dumps(payload) + "\n")
+                        f.flush()
+                        break
+                    except Exception as exc:
+                        last_error = exc
+                        if attempt < max_retries - 1:
+                            time.sleep(retry_delay * (attempt + 1))
+                        else:
+                            raise RuntimeError(
+                                f"Failed to generate sample {sample_index} for prompt: {prompt}"
+                            ) from last_error
+
+    print(f"Saved responses to {output_path}")
+    return str(output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate benchmark responses with an OpenAI-compatible API"
+    )
+    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument("--provider", type=str, default="featherless", choices=["featherless", "openai"])
+    parser.add_argument("--test-path", type=str, default=str(DEFAULT_TEST))
+    parser.add_argument("--output", type=str, default=None)
+    parser.add_argument("--base-url", type=str, default=None)
+    parser.add_argument("--api-key-env", type=str, default=None)
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--samples-per-prompt", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--max-retries", type=int, default=3)
+    parser.add_argument("--retry-delay", type=float, default=4.0)
+    args = parser.parse_args()
+
+    generate_remote_responses(
+        model=args.model,
+        provider=args.provider,
+        test_path=args.test_path,
+        output_path=args.output,
+        base_url=args.base_url,
+        api_key_env=args.api_key_env,
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        samples_per_prompt=args.samples_per_prompt,
+        seed=args.seed,
+        limit=args.limit,
+        max_retries=args.max_retries,
+        retry_delay=args.retry_delay,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add Featherless as an OpenAI-compatible provider for code/chat generation
- Add remote benchmark response generation for hosted model providers
- Add a Featherless benchmark matrix manifest and workflow docs

## Verification
- PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall api/routes/code_generation.py api/routes/chat_generation.py training/eval/generate_remote_responses.py training/benchmarks/run.py training/benchmarks/matrix.py
- python3 -m json.tool training/benchmarks/manifests/featherless_core_v1.json
- python3 -m benchmarks.matrix --manifest benchmarks/manifests/featherless_core_v1.json --only qwen2.5-coder-7b-instruct-featherless --dry-run