### PR TITLE
Document remote benchmark providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ If you want to suggest a new model, please open an issue in the [repository](htt
 
 We're training **open-source models** to generate Manim code using a 3-stage pipeline that distills from GPT-4o:
 
-1. **SFT** (Supervised Fine-Tuning) — Train on 5,000+ validated prompt→code pairs
-2. **DPO** (Direct Preference Optimization) — Learn from render success/failure pairs
-3. **GRPO** (Group Relative Policy Optimization) — RL with the Manim renderer as a deterministic reward signal
+1. **SFT** (Supervised Fine-Tuning): Train on 5,000+ validated prompt→code pairs
+2. **DPO** (Direct Preference Optimization): Learn from render success/failure pairs
+3. **GRPO** (Group Relative Policy Optimization): RL with the Manim renderer as a deterministic reward signal
 
-The key insight: Manim is a **deterministic verifier** — code either renders or crashes. This replaces the need for a reward model, similar to how DeepSeek-R1 uses math answer checkers.
+The key insight: Manim is a **deterministic verifier**: code either renders or crashes. This replaces the need for a reward model, similar to how DeepSeek-R1 uses math answer checkers.
 
-**Base models**: Qwen 2.5 Coder 7B, DeepSeek Coder V2 Lite, CodeLlama 7B — all using QLoRA (4-bit) to fit on free Kaggle T4 GPUs.
+**Base models**: Qwen 2.5 Coder 7B, DeepSeek Coder V2 Lite, CodeLlama 7B. All use QLoRA (4-bit) to fit on free Kaggle T4 GPUs.
 
 ## 📏 Benchmark
 

--- a/training/benchmarks/README.md
+++ b/training/benchmarks/README.md
@@ -132,6 +132,31 @@ python -m benchmarks.matrix \
 The manifest can mix:
 
 - local checkpoints via `checkpoint`
+- hosted OpenAI-compatible providers via `provider` and `model_id`
 - pre-generated API outputs via `responses_path`
 
 That lets the same benchmark stack compare open-source checkpoints and hosted model baselines.
+
+Example hosted provider run:
+
+```json
+{
+  "model": "qwen2.5-coder-7b-instruct-featherless",
+  "model_id": "Qwen/Qwen2.5-Coder-7B-Instruct",
+  "run_name": "featherless",
+  "provider": "featherless"
+}
+```
+
+`model` is the local report name. `model_id` is the provider model identifier sent to the API.
+
+The included Featherless manifest uses this path:
+
+```bash
+export FEATHERLESS_API_KEY="your-featherless-key"
+python -m benchmarks.matrix \
+  --manifest benchmarks/manifests/featherless_core_v1.json \
+  --dry-run
+```
+
+For hosted runs, `benchmarks.matrix` calls `eval.generate_remote_responses` before evaluating the generated responses with the same render-based benchmark flow.


### PR DESCRIPTION
## Summary
- Update benchmark docs to mention provider/model_id manifest runs
- Add a hosted provider manifest example for Featherless
- Explain that matrix runs generate remote responses before render evaluation

## Verification
- git diff --check -- training/benchmarks/README.md