### PR TITLE
List Featherless as a provider in api/README

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -29,6 +29,7 @@ And, depending on the model you want to use, you will need to have an API key fo
 - [OpenAI](https://openai.com/api/)
 - [Anthropic](https://www.anthropic.com/api)
 - [Google Gemini](https://ai.google.dev/gemini-api)
+- [Featherless](https://featherless.ai) for OpenAI-compatible access to hosted open-weight models. See the [Featherless guide](../docs/featherless.md) for setup details.
 
 If you are on MacOS, make sure you have `pkg-config` and `cairo` installed. You can install them using Homebrew:
 


### PR DESCRIPTION
## Summary
- Adds Featherless to the provider list in `api/README.md` alongside OpenAI, Anthropic, and Google Gemini.
- Links to `docs/featherless.md` so anyone setting up the API locally knows how to configure it.

## Test plan
- [x] No em dashes in the change.
- [x] Relative link to `../docs/featherless.md` resolves.