### PR TITLE
feat: add LiteLLM as AI gateway engine

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -21,3 +21,4 @@ azure-monitor-opentelemetry==1.4.2
 manim-physics==0.4.0
 httpx==0.27.2
 google-genai>=0.5.0
+litellm>=1.80.0,<1.87

--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -139,6 +139,7 @@ def generate_code_chat():
         "anthropic": "claude-35-sonnet",
         "deepseek": "r1",
         "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
+        "litellm": "openai/gpt-4o",
     }
 
     # Validate and set the model based on engine
@@ -155,6 +156,7 @@ def generate_code_chat():
         "anthropic": ["claude-35-sonnet"],
         "deepseek": ["r1"],
         "featherless": None,
+        "litellm": None,
     }
 
     if VALID_MODELS[engine] is not None and model not in VALID_MODELS[engine]:
@@ -328,7 +330,55 @@ That message should appear after the code, as the last message of the conversati
 
     messages.insert(0, {"role": "system", "content": general_system_prompt})
 
-    if engine == "featherless":
+    if engine == "litellm":
+        import litellm
+
+        litellm_system_prompt = general_system_prompt
+        messages[0] = {"role": "system", "content": litellm_system_prompt}
+
+        def generate():
+            try:
+                kwargs = {
+                    "model": model,
+                    "messages": messages,
+                    "temperature": data.get("temperature", 0.2),
+                    "max_tokens": data.get("maxTokens", 2048),
+                    "stream": True,
+                    "drop_params": True,
+                }
+                api_key = os.getenv("LITELLM_API_KEY")
+                if api_key:
+                    kwargs["api_key"] = api_key
+
+                stream = litellm.completion(**kwargs)
+                for chunk in stream:
+                    if not chunk.choices or not chunk.choices[0].delta:
+                        continue
+                    content = chunk.choices[0].delta.content
+                    if not content:
+                        continue
+                    if is_for_platform:
+                        text_obj = json.dumps({"type": "text", "text": content})
+                        yield f"{text_obj}\n"
+                    else:
+                        yield content
+            except Exception as e:
+                error_message = str(e)
+                if is_for_platform:
+                    yield f"{json.dumps({'type': 'error', 'text': error_message})}\n"
+                else:
+                    yield f"Error: {error_message}"
+
+        response = Response(
+            stream_with_context(generate()),
+            content_type="text/plain; charset=utf-8",
+        )
+        if is_for_platform:
+            response.headers['Transfer-Encoding'] = 'chunked'
+            response.headers['x-vercel-ai-data-stream'] = 'v1'
+        return response
+
+    elif engine == "featherless":
         api_key = os.environ.get("FEATHERLESS_API_KEY")
         if not api_key:
             return jsonify({"error": "FEATHERLESS_API_KEY is required when engine='featherless'"}), 500

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -12,6 +12,7 @@ ENGINE_DEFAULTS = {
     "anthropic": "claude-3-5-sonnet-20241022",
     "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
     "gemini": "gemini-2.5-flash",
+    "litellm": "openai/gpt-4o",
 }
 
 FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1"
@@ -65,7 +66,41 @@ def construct(self):
 4. Do not explain the code, only the code.
     """
 
-    if engine == "anthropic" or model.startswith("claude-"):
+    if engine == "litellm":
+        import litellm
+        from litellm.exceptions import AuthenticationError, NotFoundError, RateLimitError, Timeout
+
+        messages = [
+            {"role": "system", "content": general_system_prompt},
+            {"role": "user", "content": prompt_content},
+        ]
+        try:
+            kwargs = {
+                "model": model,
+                "messages": messages,
+                "temperature": 0.2,
+                "drop_params": True,
+            }
+            api_key = os.getenv("LITELLM_API_KEY")
+            if api_key:
+                kwargs["api_key"] = api_key
+
+            response = litellm.completion(**kwargs)
+            code = response.choices[0].message.content
+            return jsonify({"code": code})
+
+        except AuthenticationError as e:
+            return jsonify({"error": f"LiteLLM auth failed (check API key): {e}"}), 401
+        except NotFoundError as e:
+            return jsonify({"error": f"LiteLLM model not found (use provider/model format, e.g. openai/gpt-4o): {e}"}), 404
+        except RateLimitError as e:
+            return jsonify({"error": f"LiteLLM rate limit exceeded: {e}"}), 429
+        except Timeout as e:
+            return jsonify({"error": f"LiteLLM request timed out: {e}"}), 504
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+    elif engine == "anthropic" or model.startswith("claude-"):
         client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
         messages = [{"role": "user", "content": prompt_content}]
         try:

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,227 @@
+"""Tests for LiteLLM engine integration in generative-manim API."""
+
+import json
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+# Stub litellm before any app imports
+_fake_litellm = types.ModuleType("litellm")
+_fake_exceptions = types.ModuleType("litellm.exceptions")
+
+
+class _AuthenticationError(Exception):
+    pass
+
+
+class _NotFoundError(Exception):
+    pass
+
+
+class _RateLimitError(Exception):
+    pass
+
+
+class _Timeout(Exception):
+    pass
+
+
+_fake_exceptions.AuthenticationError = _AuthenticationError
+_fake_exceptions.NotFoundError = _NotFoundError
+_fake_exceptions.RateLimitError = _RateLimitError
+_fake_exceptions.Timeout = _Timeout
+
+_fake_litellm.exceptions = _fake_exceptions
+_fake_litellm.completion = mock.MagicMock()
+
+sys.modules["litellm"] = _fake_litellm
+sys.modules["litellm.exceptions"] = _fake_exceptions
+
+
+def _make_response(content):
+    msg = mock.MagicMock()
+    msg.content = content
+    choice = mock.MagicMock()
+    choice.message = msg
+    resp = mock.MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+def _make_streaming_response(text):
+    chunks = []
+    for char in text:
+        chunk = mock.MagicMock()
+        chunk.choices = [mock.MagicMock()]
+        chunk.choices[0].delta = mock.MagicMock()
+        chunk.choices[0].delta.content = char
+        chunks.append(chunk)
+    return iter(chunks)
+
+
+@pytest.fixture(autouse=True)
+def reset_mocks():
+    _fake_litellm.completion.reset_mock()
+    _fake_litellm.completion.side_effect = None
+    _fake_litellm.completion.return_value = _make_response("from manim import *\nclass GenScene(Scene):\n  pass")
+    yield
+
+
+@pytest.fixture
+def app():
+    sys.path.insert(0, ".")
+    from api.run import app
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestCodeGenerationLiteLLM:
+    """Tests for the /v1/code/generation endpoint with litellm engine."""
+
+    def test_basic_code_generation(self, client):
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "Create a blue circle",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "code" in data
+        _fake_litellm.completion.assert_called_once()
+
+    def test_drop_params_true(self, client):
+        client.post("/v1/code/generation", json={
+            "prompt": "Create a circle",
+            "engine": "litellm",
+            "model": "anthropic/claude-sonnet-4-6",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    def test_model_forwarded(self, client):
+        client.post("/v1/code/generation", json={
+            "prompt": "Create a circle",
+            "engine": "litellm",
+            "model": "groq/llama-3.3-70b-versatile",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        assert call_kwargs["model"] == "groq/llama-3.3-70b-versatile"
+
+    def test_provider_prefixed_model(self, client):
+        client.post("/v1/code/generation", json={
+            "prompt": "Create a circle",
+            "engine": "litellm",
+            "model": "anthropic/claude-haiku-4-5",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        assert "/" in call_kwargs["model"]
+
+    def test_default_model_when_not_specified(self, client):
+        client.post("/v1/code/generation", json={
+            "prompt": "Create a circle",
+            "engine": "litellm",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        assert call_kwargs["model"] == "openai/gpt-4o"
+
+    def test_api_key_from_env(self, client, monkeypatch):
+        monkeypatch.setenv("LITELLM_API_KEY", "sk-test-key")
+        client.post("/v1/code/generation", json={
+            "prompt": "Create a circle",
+            "engine": "litellm",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-test-key"
+
+    def test_api_key_omitted_when_not_set(self, client, monkeypatch):
+        monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+        client.post("/v1/code/generation", json={
+            "prompt": "Create a circle",
+            "engine": "litellm",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        assert "api_key" not in call_kwargs
+
+    def test_messages_structure(self, client):
+        client.post("/v1/code/generation", json={
+            "prompt": "Create a blue circle",
+            "engine": "litellm",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        messages = call_kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert "Manim" in messages[0]["content"]
+        assert messages[1]["role"] == "user"
+        assert "blue circle" in messages[1]["content"]
+
+
+class TestCodeGenerationLiteLLMErrors:
+    """Tests for litellm-specific error handling."""
+
+    def test_auth_error_returns_401(self, client):
+        _fake_litellm.completion.side_effect = _AuthenticationError("Invalid key")
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 401
+        assert "auth" in resp.get_json()["error"].lower()
+
+    def test_not_found_returns_404(self, client):
+        _fake_litellm.completion.side_effect = _NotFoundError("Model not found")
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 404
+
+    def test_rate_limit_returns_429(self, client):
+        _fake_litellm.completion.side_effect = _RateLimitError("429")
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 429
+
+    def test_timeout_returns_504(self, client):
+        _fake_litellm.completion.side_effect = _Timeout("timed out")
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 504
+
+    def test_generic_error_returns_500(self, client):
+        _fake_litellm.completion.side_effect = RuntimeError("unexpected")
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 500
+
+
+class TestChatGenerationLiteLLMEngine:
+    """Tests that litellm is accepted as a valid engine in chat generation."""
+
+    def test_litellm_engine_accepted(self, client):
+        _fake_litellm.completion.return_value = _make_streaming_response("Hello!")
+        resp = client.post("/v1/chat/generation", json={
+            "prompt": "Create a circle animation",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+        })
+        assert resp.status_code == 200
+
+    def test_litellm_invalid_engine_rejected(self, client):
+        resp = client.post("/v1/chat/generation", json={
+            "prompt": "test",
+            "engine": "nonexistent_engine",
+        })
+        assert resp.status_code == 400

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -207,8 +207,49 @@ class TestCodeGenerationLiteLLMErrors:
         assert resp.status_code == 500
 
 
+class TestCodeGenerationLiteLLMEdgeCases:
+    """Edge case tests for empty/null responses, streaming, etc."""
+
+    def test_empty_response_content(self, client):
+        _fake_litellm.completion.return_value = _make_response("")
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()["code"] == ""
+
+    def test_null_response_content(self, client):
+        _fake_litellm.completion.return_value = _make_response(None)
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 200
+
+    def test_no_choices_raises_500(self, client):
+        bad_resp = mock.MagicMock()
+        bad_resp.choices = []
+        _fake_litellm.completion.return_value = bad_resp
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 500
+
+    def test_context_length_exceeded(self, client):
+        """Token limit / context window overflow returns 500."""
+        _fake_litellm.completion.side_effect = RuntimeError("context_length_exceeded")
+        resp = client.post("/v1/code/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+        })
+        assert resp.status_code == 500
+        assert "context_length" in resp.get_json()["error"]
+
+
 class TestChatGenerationLiteLLMEngine:
-    """Tests that litellm is accepted as a valid engine in chat generation."""
+    """Tests for litellm streaming in chat generation."""
 
     def test_litellm_engine_accepted(self, client):
         _fake_litellm.completion.return_value = _make_streaming_response("Hello!")
@@ -225,3 +266,82 @@ class TestChatGenerationLiteLLMEngine:
             "engine": "nonexistent_engine",
         })
         assert resp.status_code == 400
+
+    def test_streaming_response_content(self, client):
+        _fake_litellm.completion.return_value = _make_streaming_response("Hello world")
+        resp = client.post("/v1/chat/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+        })
+        assert resp.status_code == 200
+        assert "Hello world" in resp.get_data(as_text=True)
+
+    def test_streaming_partial_chunks(self, client):
+        """Verify None content chunks are skipped gracefully."""
+        chunks = []
+        for text in ["Hello", None, " world", None]:
+            chunk = mock.MagicMock()
+            chunk.choices = [mock.MagicMock()]
+            chunk.choices[0].delta = mock.MagicMock()
+            chunk.choices[0].delta.content = text
+            chunks.append(chunk)
+        _fake_litellm.completion.return_value = iter(chunks)
+
+        resp = client.post("/v1/chat/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+        })
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert "Hello" in body
+        assert "world" in body
+
+    def test_streaming_empty_response(self, client):
+        """Empty stream returns 200 with no content."""
+        final = mock.MagicMock()
+        final.choices = [mock.MagicMock()]
+        final.choices[0].delta = mock.MagicMock()
+        final.choices[0].delta.content = None
+        _fake_litellm.completion.return_value = iter([final])
+
+        resp = client.post("/v1/chat/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+        })
+        assert resp.status_code == 200
+
+    def test_streaming_error_handled(self, client):
+        """Error during streaming returns error message."""
+        _fake_litellm.completion.side_effect = RuntimeError("connection lost")
+        resp = client.post("/v1/chat/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+        })
+        assert resp.status_code == 200
+        assert "Error" in resp.get_data(as_text=True)
+
+    def test_streaming_drop_params(self, client):
+        _fake_litellm.completion.return_value = _make_streaming_response("ok")
+        client.post("/v1/chat/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+        })
+        call_kwargs = _fake_litellm.completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    def test_platform_mode_json_format(self, client):
+        _fake_litellm.completion.return_value = _make_streaming_response("Hi")
+        resp = client.post("/v1/chat/generation", json={
+            "prompt": "test",
+            "engine": "litellm",
+            "model": "openai/gpt-4o",
+            "isForPlatform": True,
+        })
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert '"type": "text"' in body


### PR DESCRIPTION


## Summary
- Adds LiteLLM as a new engine option for both code generation and chat generation endpoints, giving users access to 100+ LLM providers (Groq, Together AI, AWS Bedrock, Azure, Mistral, Cohere, etc.) through a single `engine: "litellm"` setting
- Uses provider-prefixed model strings (e.g. `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, `groq/llama-3.3-70b-versatile`)



## Motivation
Generative Manim currently supports OpenAI, Anthropic, Gemini, and Featherless as separate engines. Each new provider requires its own code branch. LiteLLM provides a single `litellm.completion()` call that routes to 100+ providers using provider-prefixed model strings. Users just set `engine: "litellm"` and any LiteLLM-supported model string.

## Changes
- `api/routes/code_generation.py` - added `"litellm"` engine with `litellm.completion()`, `drop_params=True`, and litellm-specific error handling (401/404/429/504 status codes)
- `api/routes/chat_generation.py` - added `"litellm"` engine with streaming support following the featherless pattern, works with both platform and non-platform modes
- `api/requirements.txt` - added `litellm>=1.80.0,<1.87`
- `tests/test_litellm_provider.py` - 25 unit tests

## Key design decisions
- **`drop_params=True` always set** - silently drops per-provider-unsupported kwargs
- **litellm-specific HTTP status codes** - `AuthenticationError` returns 401, `NotFoundError` returns 404, `RateLimitError` returns 429, `Timeout` returns 504
- **API key optional** - reads from `LITELLM_API_KEY` env var when set, otherwise LiteLLM reads from provider env vars (`ANTHROPIC_API_KEY`, `GROQ_API_KEY`, etc.)
- **Chat generation uses featherless streaming pattern** - simple streaming without function calling for the initial integration; function calling can be added in a follow-up

## Tests

**1. Unit tests (25 passed):**
```
TestCodeGenerationLiteLLM::test_basic_code_generation PASSED
TestCodeGenerationLiteLLM::test_drop_params_true PASSED
TestCodeGenerationLiteLLM::test_model_forwarded PASSED
TestCodeGenerationLiteLLM::test_provider_prefixed_model PASSED
TestCodeGenerationLiteLLM::test_default_model_when_not_specified PASSED
TestCodeGenerationLiteLLM::test_api_key_from_env PASSED
TestCodeGenerationLiteLLM::test_api_key_omitted_when_not_set PASSED
TestCodeGenerationLiteLLM::test_messages_structure PASSED
TestCodeGenerationLiteLLMErrors::test_auth_error_returns_401 PASSED
TestCodeGenerationLiteLLMErrors::test_not_found_returns_404 PASSED
TestCodeGenerationLiteLLMErrors::test_rate_limit_returns_429 PASSED
TestCodeGenerationLiteLLMErrors::test_timeout_returns_504 PASSED
TestCodeGenerationLiteLLMErrors::test_generic_error_returns_500 PASSED
TestCodeGenerationLiteLLMEdgeCases::test_empty_response_content PASSED
TestCodeGenerationLiteLLMEdgeCases::test_null_response_content PASSED
TestCodeGenerationLiteLLMEdgeCases::test_no_choices_raises_500 PASSED
TestCodeGenerationLiteLLMEdgeCases::test_context_length_exceeded PASSED
TestChatGenerationLiteLLMEngine::test_litellm_engine_accepted PASSED
TestChatGenerationLiteLLMEngine::test_litellm_invalid_engine_rejected PASSED
TestChatGenerationLiteLLMEngine::test_streaming_response_content PASSED
TestChatGenerationLiteLLMEngine::test_streaming_partial_chunks PASSED
TestChatGenerationLiteLLMEngine::test_streaming_empty_response PASSED
TestChatGenerationLiteLLMEngine::test_streaming_error_handled PASSED
TestChatGenerationLiteLLMEngine::test_streaming_drop_params PASSED
TestChatGenerationLiteLLMEngine::test_platform_mode_json_format PASSED
======================= 25 passed in 0.81s
```

**Edge cases covered:**
- Auth error (401), model not found (404), rate limit (429), timeout (504)
- Empty/null response content, no choices in response
- Context length exceeded (token limit overflow)
- Streaming: partial chunks with None content, empty stream, error during stream
- Platform mode JSON output format
- drop_params=True on both code and chat endpoints

## Risk / Compatibility
- Additive only, existing OpenAI/Anthropic/Gemini/Featherless paths untouched
- LiteLLM is a new requirement in `api/requirements.txt`

## Example usage

**Code generation:**
```bash
curl -X POST http://localhost:5001/v1/code/generation \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "Create an animation of a bouncing ball",
    "engine": "litellm",
    "model": "anthropic/claude-sonnet-4-6"
  }'
```

**Chat generation (streaming):**
```bash
curl -X POST http://localhost:5001/v1/chat/generation \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "Create a rotating cube animation",
    "engine": "litellm",
    "model": "groq/llama-3.3-70b-versatile"
  }'
```

```python
import litellm

response = litellm.completion(
    model="anthropic/claude-sonnet-4-6",
    messages=[
        {"role": "system", "content": "You are a Manim animation expert."},
        {"role": "user", "content": "Create a blue circle animation"},
    ],
    drop_params=True,
)
print(response.choices[0].message.content)
```

See https://docs.litellm.ai/docs/providers for 100+ supported providers.
