### PR TITLE
fix: avoid leaking raw exception messages in streaming error responses

### DIFF
--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -363,11 +363,12 @@ Rules:
                     else:
                         yield content
             except Exception as e:
-                error_message = str(e)
+                print(f"Streaming error: {e}")
+                safe_message = f"{type(e).__name__}: generation failed"
                 if is_for_platform:
-                    yield f"{json.dumps({'type': 'error', 'text': error_message})}\n"
+                    yield f"{json.dumps({'type': 'error', 'text': safe_message})}\n"
                 else:
-                    yield f"Error: {error_message}"
+                    yield f"Error: {safe_message}"
 
         response = Response(
             stream_with_context(generate()),


### PR DESCRIPTION
## Summary
- Raw exception messages (which can contain API keys, internal URLs, or provider details) were being sent directly to API clients in the featherless streaming error handler
- Now logs the full error server-side and returns only `ExceptionType: generation failed` to callers
- The same pattern should be applied to the litellm streaming handler in #61 when that PR is merged

## What changed
`api/routes/chat_generation.py` — featherless `generate()` exception handler now prints the full error and returns a sanitized message.

## Related
Follows up on #61 where the same pattern was introduced for the litellm engine.