### PR TITLE
feat: add structured request validation to all API routes

### DIFF
--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -10,6 +10,7 @@ import random
 import re
 import base64
 from api.prompts.manimDocs import manimDocs
+from api.validation import get_json_body
 from azure.storage.blob import BlobServiceClient
 from PIL import Image
 import io
@@ -119,7 +120,9 @@ def generate_code_chat():
     """
     print("Received request for /v1/chat/generation")
 
-    data = request.json
+    data, err = get_json_body()
+    if err:
+        return err
     print(f"Request data: {json.dumps(data, indent=2)}")
 
     messages = data.get("messages", [])

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -3,6 +3,7 @@ import anthropic
 import os
 from openai import OpenAI
 from api.llm_providers import generate_gemini_content
+from api.validation import get_json_body
 
 code_generation_bp = Blueprint('code_generation', __name__)
 
@@ -33,16 +34,21 @@ def get_openai_compatible_client(engine: str) -> OpenAI:
 
 @code_generation_bp.route('/v1/code/generation', methods=['POST'])
 def generate_code():
-    body = request.json
+    body, err = get_json_body()
+    if err:
+        return err
+
     prompt_content = body.get("prompt", "")
     engine = body.get("engine", "openai")
 
-    if engine not in ENGINE_DEFAULTS:
+    if not isinstance(engine, str) or engine not in ENGINE_DEFAULTS:
         return jsonify({
             "error": f"Invalid engine. Must be one of: {', '.join(ENGINE_DEFAULTS.keys())}"
         }), 400
 
     model = body.get("model", ENGINE_DEFAULTS[engine])
+    if model is not None and not isinstance(model, str):
+        return jsonify({"error": "'model' must be a string"}), 400
 
     general_system_prompt = """
 You are an assistant that knows about Manim. Manim is a mathematical animation engine that is used to create videos programmatically.

--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -6,6 +6,7 @@ import subprocess
 import uuid
 from openai import OpenAI
 from api.llm_providers import generate_gemini_content
+from api.validation import get_json_body, require_string, validate_aspect_ratio
 
 video_generation_bp = Blueprint('video_generation', __name__)
 
@@ -98,19 +99,24 @@ def generate_video():
         "iteration": 1  // Optional
     }
     """
-    try:
-        # Extract parameters
-        prompt = request.json.get("prompt")
-        engine = request.json.get("engine", "openai")
-        model = request.json.get("model", "gpt-4o")
-        aspect_ratio = request.json.get("aspect_ratio", "16:9")
-        user_id = request.json.get("user_id") or str(uuid.uuid4())
-        project_name = request.json.get("project_name", "untitled")
-        iteration = request.json.get("iteration", 1)
+    body, err = get_json_body()
+    if err:
+        return err
 
-        # Validate prompt
-        if not prompt:
-            return jsonify({"error": "A 'prompt' must be provided"}), 400
+    try:
+        prompt, err = require_string(body, "prompt")
+        if err:
+            return err
+
+        aspect_ratio, err = validate_aspect_ratio(body)
+        if err:
+            return err
+
+        engine = body.get("engine", "openai")
+        model = body.get("model", "gpt-4o")
+        user_id = body.get("user_id") or str(uuid.uuid4())
+        project_name = body.get("project_name", "untitled")
+        iteration = body.get("iteration", 1)
 
         print(f"Generating video from prompt: {prompt}")
 

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -11,6 +11,7 @@ from typing import Union
 import uuid
 import time
 import requests
+from api.validation import get_json_body, require_string, validate_aspect_ratio, validate_boolean
 
 video_rendering_bp = Blueprint("video_rendering", __name__)
 
@@ -91,25 +92,29 @@ def render_video():
     # Now that we have a valid user_id, create a run
     # run_id = create_run_on_user(user_id, "video")
     
-    # Extract the rest of the request data
-    code = request.json.get("code")
-    file_name = request.json.get("file_name")
-    file_class = request.json.get("file_class")
+    body, err = get_json_body()
+    if err:
+        return err
 
-    user_id = request.json.get("user_id") or str(uuid.uuid4())
-    project_name = request.json.get("project_name")
-    iteration = request.json.get("iteration")
+    code, err = require_string(body, "code")
+    if err:
+        return err
 
-    # Aspect Ratio can be: "16:9" (default), "1:1", "9:16"
-    aspect_ratio = request.json.get("aspect_ratio")
+    aspect_ratio, err = validate_aspect_ratio(body)
+    if err:
+        return err
 
-    # Stream the percentage of animation it shown in the error
-    stream = request.json.get("stream", False)
+    stream, err = validate_boolean(body, "stream", default=False)
+    if err:
+        return err
+
+    file_name = body.get("file_name")
+    file_class = body.get("file_class")
+    user_id = body.get("user_id") or str(uuid.uuid4())
+    project_name = body.get("project_name")
+    iteration = body.get("iteration")
 
     video_storage_file_name = f"video-{user_id}-{project_name}-{iteration}"
-
-    if not code:
-        return jsonify(error="No code provided"), 400
 
     # Determine frame size and width based on aspect ratio
     frame_size, frame_width = get_frame_config(aspect_ratio)

--- a/api/validation.py
+++ b/api/validation.py
@@ -1,0 +1,59 @@
+"""Request body validation helpers for the Flask API routes."""
+
+from flask import jsonify, request
+
+
+VALID_ASPECT_RATIOS = {"16:9", "9:16", "1:1"}
+
+
+def get_json_body():
+    """Return parsed JSON body or a 400 error response tuple.
+
+    Callers should check: ``body, err = get_json_body(); if err: return err``
+    """
+    body = request.get_json(silent=True)
+    if body is None:
+        return None, (jsonify({"error": "Request body must be valid JSON with Content-Type: application/json"}), 400)
+    if not isinstance(body, dict):
+        return None, (jsonify({"error": "Request body must be a JSON object"}), 400)
+    return body, None
+
+
+def require_string(body, field, allow_empty=False):
+    """Validate that *field* exists and is a non-empty string.
+
+    Returns ``(value, None)`` on success or ``(None, error_response)`` on failure.
+    """
+    value = body.get(field)
+    if value is None:
+        return None, (jsonify({"error": f"'{field}' is required"}), 400)
+    if not isinstance(value, str):
+        return None, (jsonify({"error": f"'{field}' must be a string"}), 400)
+    if not allow_empty and not value.strip():
+        return None, (jsonify({"error": f"'{field}' must not be empty"}), 400)
+    return value, None
+
+
+def validate_aspect_ratio(body, default="16:9"):
+    """Validate the optional 'aspect_ratio' field.
+
+    Returns ``(value, None)`` on success or ``(default, error_response)`` if invalid.
+    """
+    value = body.get("aspect_ratio", default)
+    if value not in VALID_ASPECT_RATIOS:
+        return None, (
+            jsonify({"error": f"'aspect_ratio' must be one of: {', '.join(sorted(VALID_ASPECT_RATIOS))}"}),
+            400,
+        )
+    return value, None
+
+
+def validate_boolean(body, field, default=False):
+    """Validate an optional boolean field.
+
+    Returns ``(value, None)`` on success or ``(None, error_response)`` if invalid.
+    """
+    value = body.get(field, default)
+    if not isinstance(value, bool):
+        return None, (jsonify({"error": f"'{field}' must be a boolean"}), 400)
+    return value, None


### PR DESCRIPTION
## Summary

- Adds `api/validation.py` with four reusable helpers: `get_json_body()`, `require_string()`, `validate_aspect_ratio()`, and `validate_boolean()`
- Wires validation into all four route blueprints to replace raw `request.json.get()` calls

Before this change, sending a request with the wrong `Content-Type` (or malformed JSON) would crash any route with `AttributeError: 'NoneType' object has no attribute 'get'`. After: consistent 400 responses with clear messages.

Specific improvements per route:
- `/v1/code/generation`: null body guard, type-check on `engine` and `model`
- `/v1/video/generation`: null body guard, `prompt` required string, `aspect_ratio` enum validation
- `/v1/video/rendering`: null body guard, `code` required string, `aspect_ratio` enum, `stream` boolean check
- `/v1/chat/generation`: null body guard

## Test plan

- [ ] `curl -X POST http://localhost:8080/v1/video/rendering -H "Content-Type: text/plain" -d "bad"` should return 400
- [ ] `curl -X POST http://localhost:8080/v1/video/generation -H "Content-Type: application/json" -d '{"prompt":"test","aspect_ratio":"bad"}'` should return 400 with helpful message
- [ ] All existing tests still pass: `python -m pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)