### PR TITLE
feat: add Gemini streaming to /v1/chat/generation

### DIFF
--- a/api/llm_providers.py
+++ b/api/llm_providers.py
@@ -1,4 +1,5 @@
 import os
+from typing import Iterator
 
 try:
     from google import genai
@@ -44,3 +45,41 @@ def generate_gemini_content(model: str, system_prompt: str, prompt: str) -> str:
         contents=f"{system_prompt.strip()}\n\nUser request: {prompt}",
     )
     return strip_markdown_code_fence(response.text)
+
+
+def generate_gemini_content_stream(
+    model: str, system_prompt: str, messages: list
+) -> Iterator[str]:
+    """Yield text chunks from a Gemini streaming response.
+
+    *messages* is a list of ``{"role": ..., "content": ...}`` dicts. The
+    system prompt is prepended as a plain string so Gemini receives the full
+    conversation context (the API does not support a separate system role).
+    """
+    if genai is None:
+        raise RuntimeError("google-genai is required to use Gemini models")
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY is required to use Gemini models")
+
+    client = genai.Client(api_key=api_key)
+
+    parts = [system_prompt.strip()]
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                item.get("text", "") for item in content if isinstance(item, dict)
+            )
+        parts.append(f"{role.capitalize()}: {content}")
+
+    contents = "\n\n".join(parts)
+
+    for chunk in client.models.generate_content_stream(
+        model=normalize_gemini_model(model),
+        contents=contents,
+    ):
+        if chunk.text:
+            yield chunk.text

--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -10,6 +10,7 @@ import random
 import re
 import base64
 from api.prompts.manimDocs import manimDocs
+from api.llm_providers import generate_gemini_content_stream
 from azure.storage.blob import BlobServiceClient
 from PIL import Image
 import io
@@ -140,6 +141,7 @@ def generate_code_chat():
         "deepseek": "r1",
         "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
         "litellm": "openai/gpt-4o",
+        "gemini": "gemini-2.5-flash",
     }
 
     # Validate and set the model based on engine
@@ -157,6 +159,7 @@ def generate_code_chat():
         "deepseek": ["r1"],
         "featherless": None,
         "litellm": None,
+        "gemini": None,
     }
 
     if VALID_MODELS[engine] is not None and model not in VALID_MODELS[engine]:
@@ -427,6 +430,33 @@ Rules:
         if is_for_platform:
             response.headers['Transfer-Encoding'] = 'chunked'
             response.headers['x-vercel-ai-data-stream'] = 'v1'
+        return response
+
+    if engine == "gemini":
+        gemini_system_prompt = general_system_prompt
+
+        def generate():
+            try:
+                for chunk in generate_gemini_content_stream(model, gemini_system_prompt, messages):
+                    if is_for_platform:
+                        text_obj = json.dumps({"type": "text", "text": chunk})
+                        yield f"{text_obj}\n"
+                    else:
+                        yield chunk
+            except Exception as e:
+                safe_message = f"{type(e).__name__}: generation failed"
+                if is_for_platform:
+                    yield f"{json.dumps({'type': 'error', 'text': safe_message})}\n"
+                else:
+                    yield f"Error: {safe_message}"
+
+        response = Response(
+            stream_with_context(generate()),
+            content_type="text/plain; charset=utf-8",
+        )
+        if is_for_platform:
+            response.headers["Transfer-Encoding"] = "chunked"
+            response.headers["x-vercel-ai-data-stream"] = "v1"
         return response
 
     if engine == "anthropic":


### PR DESCRIPTION
## Summary

- Adds `generate_gemini_content_stream()` to `api/llm_providers.py` — yields text chunks from `client.models.generate_content_stream()`, building a flat conversation string from the messages list (Gemini does not support a separate system role)
- Registers `gemini` engine in `ENGINE_DEFAULTS` and `VALID_MODELS` inside `/v1/chat/generation`
- Adds a streaming response block for the Gemini engine that matches the `is_for_platform` JSON envelope format used by OpenAI, Anthropic, Featherless, and LiteLLM engines

Before this PR, sending `{"engine": "gemini"}` to `/v1/chat/generation` returned a 400 ("Invalid engine"). After: the request streams back Gemini responses in the same SSE format as other engines.

## Test plan

- [ ] `python -m pytest tests/ -v` — all tests pass
- [ ] `curl -N -X POST http://localhost:8080/v1/chat/generation -H "Content-Type: application/json" -d '{"prompt":"draw a circle","engine":"gemini","model":"gemini-2.5-flash"}'` streams response chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)