### PR TITLE
feat: add /health and /v1/health endpoints

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -5,6 +5,7 @@ from .routes.video_rendering import video_rendering_bp
 from .routes.code_generation import code_generation_bp
 from .routes.chat_generation import chat_generation_bp
 from .routes.video_generation import video_generation_bp
+from .routes.health import health_bp
 
 def create_app():
     app = Flask(__name__, static_folder="public", static_url_path="/public")
@@ -15,6 +16,7 @@ def create_app():
     app.register_blueprint(code_generation_bp)
     app.register_blueprint(chat_generation_bp)
     app.register_blueprint(video_generation_bp)
+    app.register_blueprint(health_bp)
 
     CORS(app)
     

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,0 +1,36 @@
+"""Health check endpoint for the Generative Manim API."""
+
+import os
+from flask import Blueprint, jsonify
+
+health_bp = Blueprint("health", __name__)
+
+_PROVIDERS = {
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "featherless": "FEATHERLESS_API_KEY",
+    "litellm": "LITELLM_API_KEY",
+}
+
+
+def _check_providers() -> dict:
+    return {
+        name: {"configured": bool(os.getenv(env_var)), "env_var": env_var}
+        for name, env_var in _PROVIDERS.items()
+    }
+
+
+@health_bp.route("/health", methods=["GET"])
+@health_bp.route("/v1/health", methods=["GET"])
+def health():
+    providers = _check_providers()
+    configured_count = sum(1 for p in providers.values() if p["configured"])
+    status = "healthy" if configured_count > 0 else "degraded"
+
+    return jsonify({
+        "status": status,
+        "providers": providers,
+        "configured_providers": configured_count,
+        "total_providers": len(providers),
+    }), 200


### PR DESCRIPTION
## Summary

- Adds `api/routes/health.py` with a `health_bp` blueprint registered at both `/health` and `/v1/health`
- Returns a JSON object with per-provider key configuration status and an overall `healthy`/`degraded` status
- A deployment with no API keys configured returns `"status": "degraded"`; any configured key returns `"status": "healthy"`

Example response:
```json
{
  "status": "healthy",
  "configured_providers": 2,
  "total_providers": 5,
  "providers": {
    "openai": {"configured": true, "env_var": "OPENAI_API_KEY"},
    "anthropic": {"configured": true, "env_var": "ANTHROPIC_API_KEY"},
    "gemini": {"configured": false, "env_var": "GEMINI_API_KEY"},
    "featherless": {"configured": false, "env_var": "FEATHERLESS_API_KEY"},
    "litellm": {"configured": false, "env_var": "LITELLM_API_KEY"}
  }
}
```

## Test plan

- [ ] `curl http://localhost:8080/health` returns 200 with provider map
- [ ] `curl http://localhost:8080/v1/health` returns the same response
- [ ] `python -m pytest tests/ -v` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)