### PR TITLE
feat: update Anthropic default to claude-sonnet-4-6 and add Claude 4 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ It began as a prototype of a web app that uses [GPT-4](https://openai.com/resear
 | GM GPT-3.5 Fine Tuned         | First Fine-tuned model of GPT-3.5                                         | GPT-3.5                    | ✅    |
 | GM GPT-3.5 Physics Fine Tuned | Fine-tuned GPT-3.5 model trained to generate Physics animations           | GPT-3.5                    | ✅    |
 | GM Claude Sonnet              | Claude Sonnet 3 model from Sonnet adapted with our custom System Prompt   | claude-3-sonnet-20240229   | ✅    |
-| GM Claude Sonnet 3.5          | Claude Sonnet 3.5 model from Sonnet adapted with our custom System Prompt | claude-3-5-sonnet-20240620 | ✅    |
+| GM Claude Sonnet 3.5          | Claude Sonnet 3.5 model from Sonnet adapted with our custom System Prompt | claude-3-5-sonnet-20241022 | ✅    |
+| GM Claude Sonnet 4.6          | Claude Sonnet 4.6 (default Anthropic model) adapted with our custom System Prompt | claude-sonnet-4-6 | ✅    |
+| GM Claude Opus 4.7            | Claude Opus 4.7 for highest-quality Anthropic generation                  | claude-opus-4-7            | ✅    |
+| GM Claude Haiku 4.5           | Claude Haiku 4.5 for fast, lightweight Anthropic generation               | claude-haiku-4-5-20251001  | ✅    |
 | GM Featherless Open Models    | OpenAI-compatible access to hosted open-weight models via Featherless     | Qwen, DeepSeek, CodeLlama, etc. | ✅ |
 | GM Gemini 2.5 Flash           | Google's Gemini 2.5 Flash accessed via google-genai SDK                  | gemini-2.5-flash           | ✅    |
 | GM Gemini 3 Flash             | Google's Gemini 3 Flash preview accessed via google-genai SDK            | gemini-3-flash-preview     | ✅    |

--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -223,7 +223,7 @@ def generate_code_chat():
     # Define default models for each engine
     ENGINE_DEFAULTS = {
         "openai": "gpt-4o",
-        "anthropic": "claude-35-sonnet",
+        "anthropic": "claude-sonnet-4-6",
         "deepseek": "r1",
         "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
         "litellm": "openai/gpt-4o",
@@ -241,7 +241,14 @@ def generate_code_chat():
     # Validate model based on engine
     VALID_MODELS = {
         "openai": ["gpt-4o", "o1-mini"],
-        "anthropic": ["claude-35-sonnet"],
+        "anthropic": [
+            "claude-sonnet-4-6",
+            "claude-opus-4-7",
+            "claude-haiku-4-5-20251001",
+            "claude-3-5-sonnet-20241022",
+            "claude-3-5-haiku-20241022",
+            "claude-35-sonnet",
+        ],
         "deepseek": ["r1"],
         "featherless": None,
         "litellm": None,
@@ -575,7 +582,7 @@ Rules:
                     print("\n=== End of message history ===")
                     
                     stream = client.messages.create(
-                        model="claude-3-5-sonnet-20241022",
+                        model=model,
                         messages=messages,
                         system=system_message,
                         max_tokens=1000,

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -10,7 +10,7 @@ code_generation_bp = Blueprint('code_generation', __name__)
 
 ENGINE_DEFAULTS = {
     "openai": "gpt-4o",
-    "anthropic": "claude-3-5-sonnet-20241022",
+    "anthropic": "claude-sonnet-4-6",
     "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
     "gemini": "gemini-2.5-flash",
     "litellm": "openai/gpt-4o",

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -145,7 +145,7 @@ class TestCodeGenerationAnthropic:
         data = resp.get_json()
         assert data["code"] == "from manim import *"
 
-    def test_uses_default_claude_model(self, client, monkeypatch):
+    def test_uses_default_claude_sonnet_4_6(self, client, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         captured = {}
         with mock.patch("anthropic.Anthropic") as mock_anthropic:
@@ -154,7 +154,23 @@ class TestCodeGenerationAnthropic:
                 return _make_anthropic_response("code")
             mock_anthropic.return_value.messages.create.side_effect = capture
             client.post("/v1/code/generation", json={"prompt": "test", "engine": "anthropic"})
-        assert "claude" in captured.get("model", "")
+        assert captured.get("model") == "claude-sonnet-4-6"
+
+    def test_claude_opus_4_7_accepted(self, client, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        captured = {}
+        with mock.patch("anthropic.Anthropic") as mock_anthropic:
+            def capture(**kwargs):
+                captured.update(kwargs)
+                return _make_anthropic_response("code")
+            mock_anthropic.return_value.messages.create.side_effect = capture
+            resp = client.post("/v1/code/generation", json={
+                "prompt": "test",
+                "engine": "anthropic",
+                "model": "claude-opus-4-7",
+            })
+        assert resp.status_code == 200
+        assert captured.get("model") == "claude-opus-4-7"
 
     def test_multiple_content_blocks_joined(self, client, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")


### PR DESCRIPTION
## Summary

- Changes the default Anthropic model from `claude-3-5-sonnet-20241022` to `claude-sonnet-4-6` in both `chat_generation.py` and `code_generation.py`
- Expands the Anthropic VALID_MODELS allowlist to include `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5-20251001`, and legacy 3.5 IDs
- Fixes hardcoded model string inside the Anthropic tool-use block — now uses the request-level `model` variable
- Updates README models table with Claude Sonnet 4.6, Opus 4.7, and Haiku 4.5 entries
- Adds tests verifying the new default and that Claude Opus 4.7 is accepted without a 400

## Test plan

- [ ] 78 tests pass
- [ ] Default Anthropic model is `claude-sonnet-4-6`
- [ ] Passing `claude-opus-4-7` returns 200, not 400
- [ ] Old `claude-3-5-sonnet-20241022` still accepted (backwards compatibility)