### PR TITLE
docs: rewrite OpenAPI spec and update API README

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -146,3 +146,40 @@ The `aspect_ratio` field controls the render dimensions. Supported values are:
 - `16:9` for landscape videos
 - `9:16` for portrait videos
 - `1:1` for square videos
+
+### How to check API health?
+
+The `/health` (or `/v1/health`) endpoint returns which LLM providers are configured:
+
+```bash
+curl http://127.0.0.1:8080/health
+```
+
+Example response:
+
+```json
+{
+  "status": "healthy",
+  "configured_providers": 2,
+  "total_providers": 5,
+  "providers": {
+    "openai":      { "configured": true,  "env_var": "OPENAI_API_KEY" },
+    "anthropic":   { "configured": true,  "env_var": "ANTHROPIC_API_KEY" },
+    "gemini":      { "configured": false, "env_var": "GEMINI_API_KEY" },
+    "featherless": { "configured": false, "env_var": "FEATHERLESS_API_KEY" },
+    "litellm":     { "configured": false, "env_var": "LITELLM_API_KEY" }
+  }
+}
+```
+
+Status is `healthy` when at least one provider key is set, `degraded` when none are.
+
+## Supported engines and default models
+
+| Engine       | Default model                   | API key env var         |
+| ------------ | ------------------------------- | ----------------------- |
+| `openai`     | `gpt-4o`                        | `OPENAI_API_KEY`        |
+| `anthropic`  | `claude-sonnet-4-6`             | `ANTHROPIC_API_KEY`     |
+| `gemini`     | `gemini-2.5-flash`              | `GEMINI_API_KEY`        |
+| `featherless`| `Qwen/Qwen2.5-Coder-7B-Instruct`| `FEATHERLESS_API_KEY`   |
+| `litellm`    | `openai/gpt-4o`                 | `LITELLM_API_KEY`       |

--- a/api/public/openapi.yaml
+++ b/api/public/openapi.yaml
@@ -2,255 +2,411 @@ openapi: 3.0.1
 info:
   title: Generative Manim API
   description: API for generating Manim code, converting it to video, and handling chat-based code generation.
-  version: 1.0.0
+  version: 2.0.0
   license:
     name: Apache License, Version 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
 
 servers:
   - url: http://localhost:8080
+    description: Local development server
 
 paths:
-  /generate-code:
-    post:
-      summary: Generate Manim Code
-      description: Generates Manim code based on a provided prompt using OpenAI, Anthropic, Featherless, or Gemini models.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                prompt:
-                  type: string
-                  description: The prompt to generate Manim code.
-                  example: Create a blue circle and animate its creation.
-                model:
-                  type: string
-                  description: The model to use for code generation (for example, 'gpt-4o', 'claude-3-5-sonnet-20241022', 'gemini-2.5-flash', or 'gemini-3-flash-preview').
-                  example: gpt-4o
-                engine:
-                  type: string
-                  enum: [openai, anthropic, featherless, gemini]
-                  default: openai
+  /health:
+    get:
+      summary: Health check
+      description: Returns the health status of the API and which LLM provider API keys are configured.
+      operationId: health
       responses:
-        '200':
-          description: Successful response with generated code
+        "200":
+          description: Health status
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  code:
-                    type: string
-                    description: The generated Manim code.
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
+                $ref: "#/components/schemas/HealthResponse"
 
-  /chat:
-    post:
-      summary: Chat for Code Generation
-      description: Handles chat requests for both Anthropic and OpenAI models to assist with Manim code generation.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                messages:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      role:
-                        type: string
-                      content:
-                        oneOf:
-                          - type: string
-                          - type: array
-                            items:
-                              type: object
-                engine:
-                  type: string
-                  enum: [openai, anthropic]
-                  default: openai
+  /v1/health:
+    get:
+      summary: Health check (versioned)
+      description: Alias for /health.
+      operationId: healthV1
       responses:
-        '200':
-          description: Successful response with streaming content
+        "200":
+          description: Health status
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  stream:
-                    type: boolean
-                  response:
-                    type: object
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
+                $ref: "#/components/schemas/HealthResponse"
 
-  /v1/video/rendering:
+  /v1/code/generation:
     post:
-      summary: Convert Code to Video
-      description: Converts provided Manim code to a video and uploads it to storage.
+      summary: Generate Manim code
+      description: Generates Manim Python code from a natural-language prompt using the specified LLM engine.
+      operationId: generateCode
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                code:
-                  type: string
-                  description: The Manim code to convert to video.
-                file_name:
-                  type: string
-                  description: The name of the file to save the code.
-                file_class:
-                  type: string
-                  description: The class name to render.
-                user_id:
-                  type: string
-                  description: The user ID for the video.
-                  default: "anonymous"
-                project_name:
-                  type: string
-                  description: The project name for the video.
-                iteration:
-                  type: integer
-                  description: The iteration number for naming the video.
-                aspect_ratio:
-                  type: string
-                  description: The aspect ratio of the video (16:9, 1:1, or 9:16).
-                  default: "16:9"
-                stream:
-                  type: boolean
-                  description: Whether to stream the percentage of animation shown.
-                  default: false
+              $ref: "#/components/schemas/CodeGenerationRequest"
+            examples:
+              openai:
+                summary: OpenAI engine
+                value:
+                  prompt: Draw a blue circle and animate its creation.
+                  engine: openai
+                  model: gpt-4o
+              anthropic:
+                summary: Anthropic engine
+                value:
+                  prompt: Draw a spinning square.
+                  engine: anthropic
+                  model: claude-sonnet-4-6
+              gemini:
+                summary: Gemini engine
+                value:
+                  prompt: Animate a Fourier series approximation.
+                  engine: gemini
+                  model: gemini-2.5-flash
       responses:
-        '200':
-          description: Successful response with video URL
+        "200":
+          description: Successfully generated Manim code
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: Success message.
-                  video_url:
-                    type: string
-                    description: URL of the generated video.
-        '207':
-          description: Streaming response with animation progress
-          content:
-            text/event-stream:
-              schema:
-                type: string
-                description: JSON-encoded progress updates or error messages.
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: Error message.
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    description: Error message.
+                $ref: "#/components/schemas/CodeGenerationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /v1/chat/generation:
     post:
-      summary: Generate Chat-based Manim Code
-      description: Generates Manim code based on a chat conversation using either OpenAI or Anthropic models.
+      summary: Chat-based Manim code generation
+      description: Streams Manim code and explanations through a multi-turn conversation. Supports OpenAI, Anthropic, Gemini, Featherless, and LiteLLM engines.
+      operationId: chatGeneration
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                messages:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      role:
-                        type: string
-                      content:
-                        oneOf:
-                          - type: string
-                          - type: array
-                            items:
-                              type: object
-                globalPrompt:
-                  type: string
-                userId:
-                  type: string
-                scenes:
-                  type: array
-                  items:
-                    type: object
-                projectTitle:
-                  type: string
-                engine:
-                  type: string
-                  enum: [openai, anthropic]
-                  default: openai
-                selectedScenes:
-                  type: array
-                  items:
-                    type: string
+              $ref: "#/components/schemas/ChatGenerationRequest"
+            examples:
+              openai:
+                summary: OpenAI streaming chat
+                value:
+                  messages:
+                    - role: user
+                      content: Create a sine wave animation
+                  engine: openai
+                  model: gpt-4o
+              anthropic:
+                summary: Anthropic streaming chat
+                value:
+                  messages:
+                    - role: user
+                      content: Draw a rotating 3D cube
+                  engine: anthropic
+                  model: claude-sonnet-4-6
       responses:
-        '200':
-          description: Successful streaming response with generated content
+        "200":
+          description: Streaming response with generated content
           content:
-            text/event-stream:
+            text/plain:
               schema:
                 type: string
-                description: Streamed content from the AI model.
-        '500':
-          description: Internal Server Error
+                description: Chunked text stream. When isForPlatform is true, each chunk is a JSON object with a "type" field.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/video/rendering:
+    post:
+      summary: Render Manim code to video
+      description: Executes Manim Python code and returns a rendered MP4 video URL. Supports streaming progress updates.
+      operationId: renderVideo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VideoRenderingRequest"
+            examples:
+              basic:
+                summary: Non-streaming render
+                value:
+                  code: "from manim import *\nclass GenScene(Scene):\n    def construct(self):\n        self.play(Create(Circle()))"
+                  file_class: GenScene
+                  aspect_ratio: "16:9"
+              streaming:
+                summary: Streaming render with progress
+                value:
+                  code: "from manim import *\nclass GenScene(Scene):\n    def construct(self):\n        self.play(Create(Circle()))"
+                  file_class: GenScene
+                  stream: true
+      responses:
+        "200":
+          description: Successfully rendered video (non-streaming mode)
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
+                $ref: "#/components/schemas/VideoRenderingResponse"
+        "207":
+          description: Streaming progress updates (streaming mode). Each line is a JSON object.
+          content:
+            text/event-stream:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/RenderProgress"
+                  - $ref: "#/components/schemas/RenderComplete"
+                  - $ref: "#/components/schemas/RenderError"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /v1/video/generation:
+    post:
+      summary: Generate video from prompt
+      description: Generates Manim code from a prompt, then renders it to a video in one request.
+      operationId: generateVideo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VideoGenerationRequest"
+            examples:
+              basic:
+                summary: Generate a video
+                value:
+                  prompt: Animate a bouncing ball with gravity.
+                  engine: openai
+                  aspect_ratio: "16:9"
+      responses:
+        "200":
+          description: Successfully generated and rendered video
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VideoRenderingResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "408":
+          description: Request timeout
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
 components:
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, providers, configured_providers, total_providers]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded]
+          description: healthy if at least one provider key is configured, degraded otherwise.
+        providers:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              configured:
+                type: boolean
+              env_var:
+                type: string
+        configured_providers:
+          type: integer
+        total_providers:
+          type: integer
 
-security:
-  - ApiKeyAuth: []
+    CodeGenerationRequest:
+      type: object
+      properties:
+        prompt:
+          type: string
+          description: Natural-language description of the animation to generate.
+          example: Draw a blue circle and animate its creation.
+        engine:
+          type: string
+          enum: [openai, anthropic, featherless, gemini, litellm]
+          default: openai
+          description: LLM provider to use.
+        model:
+          type: string
+          description: Model ID for the chosen engine. Defaults to the engine's recommended model if omitted.
+          example: gpt-4o
+
+    CodeGenerationResponse:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+          description: Generated Manim Python code.
+
+    ChatGenerationRequest:
+      type: object
+      required: [messages]
+      properties:
+        messages:
+          type: array
+          description: Conversation history.
+          items:
+            $ref: "#/components/schemas/ChatMessage"
+        engine:
+          type: string
+          enum: [openai, anthropic, featherless, gemini, litellm]
+          default: openai
+        model:
+          type: string
+          description: Model ID override. Defaults to the engine's recommended model.
+        globalPrompt:
+          type: string
+          description: Additional system-level instruction injected at the beginning.
+        userId:
+          type: string
+        projectTitle:
+          type: string
+        scenes:
+          type: array
+          items:
+            type: object
+        selectedScenes:
+          type: array
+          items:
+            type: string
+        isForPlatform:
+          type: boolean
+          default: false
+          description: When true, the response uses the Vercel AI data stream format with Transfer-Encoding chunked.
+
+    ChatMessage:
+      type: object
+      required: [role, content]
+      properties:
+        role:
+          type: string
+          enum: [user, assistant, system]
+        content:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  text:
+                    type: string
+
+    VideoRenderingRequest:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+          description: Manim Python code to render.
+        file_class:
+          type: string
+          description: Name of the Manim Scene subclass to render. Defaults to GenScene.
+          default: GenScene
+        user_id:
+          type: string
+          description: User identifier used in the output file name.
+        project_name:
+          type: string
+        iteration:
+          type: integer
+        aspect_ratio:
+          type: string
+          enum: ["16:9", "9:16", "1:1"]
+          default: "16:9"
+        stream:
+          type: boolean
+          default: false
+          description: If true, returns a 207 streaming response with per-animation progress.
+
+    VideoRenderingResponse:
+      type: object
+      properties:
+        message:
+          type: string
+        video_url:
+          type: string
+          format: uri
+          description: URL of the rendered MP4.
+
+    VideoGenerationRequest:
+      type: object
+      required: [prompt]
+      properties:
+        prompt:
+          type: string
+          description: Natural-language description of the animation to generate and render.
+        engine:
+          type: string
+          enum: [openai, anthropic, featherless, gemini, litellm]
+          default: openai
+        model:
+          type: string
+        aspect_ratio:
+          type: string
+          enum: ["16:9", "9:16", "1:1"]
+          default: "16:9"
+        user_id:
+          type: string
+        project_name:
+          type: string
+        iteration:
+          type: integer
+
+    RenderProgress:
+      type: object
+      properties:
+        animationIndex:
+          type: integer
+        percentage:
+          type: integer
+          minimum: 0
+          maximum: 100
+
+    RenderComplete:
+      type: object
+      properties:
+        video_url:
+          type: string
+          format: uri
+
+    RenderError:
+      type: object
+      properties:
+        error:
+          type: string
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+
+  responses:
+    BadRequest:
+      description: Invalid request body or parameters
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    InternalServerError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"


### PR DESCRIPTION
## Summary

- Rewrites `api/public/openapi.yaml` from scratch: adds `/health`, `/v1/health`, `/v1/video/generation`; removes stale `/generate-code` and `/chat` paths; adds complete request/response schemas with `$ref` components, examples, and `oneOf` streaming discriminators
- Bumps spec version to 2.0.0
- Adds health endpoint documentation and a provider/engine reference table to `api/README.md`

## Test plan

- [ ] YAML is valid (verified with `yaml.safe_load`)
- [ ] All five endpoints documented: `/health`, `/v1/code/generation`, `/v1/chat/generation`, `/v1/video/rendering`, `/v1/video/generation`
- [ ] Engine enum includes `openai`, `anthropic`, `featherless`, `gemini`, `litellm`
- [ ] Default models in spec match `ENGINE_DEFAULTS` in code