### PR TITLE
feat: add /v1/models endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -9,6 +9,7 @@ from .routes.code_generation import code_generation_bp
 from .routes.chat_generation import chat_generation_bp
 from .routes.video_generation import video_generation_bp
 from .routes.health import health_bp
+from .routes.models import models_bp
 
 _DEFAULT_LIMITS = ["60 per minute", "500 per hour"]
 
@@ -30,6 +31,7 @@ def create_app():
     app.register_blueprint(chat_generation_bp)
     app.register_blueprint(video_generation_bp)
     app.register_blueprint(health_bp)
+    app.register_blueprint(models_bp)
 
     # Tighter per-IP limits on compute-heavy endpoints
     limiter.limit("20 per minute")(video_rendering_bp)

--- a/api/public/openapi.yaml
+++ b/api/public/openapi.yaml
@@ -38,6 +38,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/HealthResponse"
 
+  /v1/models:
+    get:
+      summary: List available models
+      description: Returns all supported engines with their available model IDs, defaults, and whether the corresponding API key is configured.
+      operationId: listModels
+      responses:
+        "200":
+          description: List of engines and their models
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ModelsResponse"
+
   /v1/code/generation:
     post:
       summary: Generate Manim code
@@ -250,6 +263,38 @@ components:
         code:
           type: string
           description: Generated Manim Python code.
+
+    ModelsResponse:
+      type: object
+      required: [engines]
+      properties:
+        engines:
+          type: array
+          items:
+            type: object
+            required: [engine, configured, default, models]
+            properties:
+              engine:
+                type: string
+                enum: [openai, anthropic, gemini, featherless, litellm]
+              configured:
+                type: boolean
+                description: True if the corresponding API key environment variable is set.
+              default:
+                type: string
+                description: Default model ID used when no model is specified.
+              models:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    description:
+                      type: string
+              note:
+                type: string
+                description: Optional extra context (e.g. for LiteLLM's open model string format).
 
     ChatGenerationRequest:
       type: object

--- a/api/routes/models.py
+++ b/api/routes/models.py
@@ -1,0 +1,69 @@
+"""List available models grouped by engine."""
+
+import os
+from flask import Blueprint, jsonify
+
+models_bp = Blueprint("models", __name__)
+
+_ENGINES = {
+    "openai": {
+        "env_var": "OPENAI_API_KEY",
+        "default": "gpt-4o",
+        "models": [
+            {"id": "gpt-4o", "description": "GPT-4o — OpenAI's latest multimodal model"},
+            {"id": "o1-mini", "description": "o1-mini — compact reasoning model"},
+        ],
+    },
+    "anthropic": {
+        "env_var": "ANTHROPIC_API_KEY",
+        "default": "claude-sonnet-4-6",
+        "models": [
+            {"id": "claude-sonnet-4-6", "description": "Claude Sonnet 4.6 — balanced speed and quality"},
+            {"id": "claude-opus-4-7", "description": "Claude Opus 4.7 — highest capability"},
+            {"id": "claude-haiku-4-5-20251001", "description": "Claude Haiku 4.5 — fastest and most compact"},
+            {"id": "claude-3-5-sonnet-20241022", "description": "Claude 3.5 Sonnet (legacy)"},
+        ],
+    },
+    "gemini": {
+        "env_var": "GEMINI_API_KEY",
+        "default": "gemini-2.5-flash",
+        "models": [
+            {"id": "gemini-2.5-flash", "description": "Gemini 2.5 Flash — fast and efficient"},
+            {"id": "gemini-2.5-pro", "description": "Gemini 2.5 Pro — highest capability"},
+        ],
+    },
+    "featherless": {
+        "env_var": "FEATHERLESS_API_KEY",
+        "default": "Qwen/Qwen2.5-Coder-7B-Instruct",
+        "models": [
+            {"id": "Qwen/Qwen2.5-Coder-7B-Instruct", "description": "Qwen 2.5 Coder 7B"},
+            {"id": "Qwen/Qwen2.5-Coder-32B-Instruct", "description": "Qwen 2.5 Coder 32B"},
+            {"id": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct", "description": "DeepSeek Coder V2 Lite"},
+            {"id": "meta-llama/CodeLlama-7b-Instruct-hf", "description": "CodeLlama 7B"},
+        ],
+    },
+    "litellm": {
+        "env_var": "LITELLM_API_KEY",
+        "default": "openai/gpt-4o",
+        "models": [],
+        "note": "Accepts any model string supported by LiteLLM (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6).",
+    },
+}
+
+
+@models_bp.route("/v1/models", methods=["GET"])
+def list_models():
+    result = []
+    for engine, info in _ENGINES.items():
+        configured = bool(os.getenv(info["env_var"]))
+        entry = {
+            "engine": engine,
+            "configured": configured,
+            "default": info["default"],
+            "models": info["models"],
+        }
+        if "note" in info:
+            entry["note"] = info["note"]
+        result.append(entry)
+
+    return jsonify({"engines": result}), 200

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,88 @@
+"""Tests for the /v1/models endpoint."""
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+_fake_litellm = types.ModuleType("litellm")
+_fake_exceptions = types.ModuleType("litellm.exceptions")
+_fake_exceptions.AuthenticationError = Exception
+_fake_exceptions.NotFoundError = Exception
+_fake_exceptions.RateLimitError = Exception
+_fake_exceptions.Timeout = Exception
+_fake_litellm.exceptions = _fake_exceptions
+_fake_litellm.completion = mock.MagicMock()
+sys.modules.setdefault("litellm", _fake_litellm)
+sys.modules.setdefault("litellm.exceptions", _fake_exceptions)
+
+
+@pytest.fixture
+def app():
+    sys.path.insert(0, ".")
+    from api.run import app
+    app.config["TESTING"] = True
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestModelsEndpoint:
+    def test_returns_200(self, client):
+        resp = client.get("/v1/models")
+        assert resp.status_code == 200
+
+    def test_response_has_engines_key(self, client):
+        data = client.get("/v1/models").get_json()
+        assert "engines" in data
+        assert isinstance(data["engines"], list)
+
+    def test_all_five_engines_present(self, client):
+        data = client.get("/v1/models").get_json()
+        engine_names = {e["engine"] for e in data["engines"]}
+        assert engine_names == {"openai", "anthropic", "gemini", "featherless", "litellm"}
+
+    def test_engine_shape(self, client):
+        data = client.get("/v1/models").get_json()
+        for entry in data["engines"]:
+            assert "engine" in entry
+            assert "configured" in entry
+            assert "default" in entry
+            assert "models" in entry
+            assert isinstance(entry["configured"], bool)
+            assert isinstance(entry["models"], list)
+
+    def test_configured_false_when_no_key(self, client, monkeypatch):
+        for var in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+                    "FEATHERLESS_API_KEY", "LITELLM_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        data = client.get("/v1/models").get_json()
+        for entry in data["engines"]:
+            assert entry["configured"] is False, f"{entry['engine']} should not be configured"
+
+    def test_configured_true_when_key_set(self, client, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        data = client.get("/v1/models").get_json()
+        openai_entry = next(e for e in data["engines"] if e["engine"] == "openai")
+        assert openai_entry["configured"] is True
+
+    def test_anthropic_default_is_claude_sonnet_4_6(self, client):
+        data = client.get("/v1/models").get_json()
+        anthropic = next(e for e in data["engines"] if e["engine"] == "anthropic")
+        assert anthropic["default"] == "claude-sonnet-4-6"
+
+    def test_anthropic_models_include_claude_4(self, client):
+        data = client.get("/v1/models").get_json()
+        anthropic = next(e for e in data["engines"] if e["engine"] == "anthropic")
+        model_ids = [m["id"] for m in anthropic["models"]]
+        assert "claude-sonnet-4-6" in model_ids
+        assert "claude-opus-4-7" in model_ids
+
+    def test_litellm_has_note(self, client):
+        data = client.get("/v1/models").get_json()
+        litellm = next(e for e in data["engines"] if e["engine"] == "litellm")
+        assert "note" in litellm


### PR DESCRIPTION
## Summary

- Adds `GET /v1/models` endpoint returning all supported engines with their model IDs, defaults, and configured status
- Blueprint registered in `api/__init__.py`
- Adds `ModelsResponse` schema to `api/public/openapi.yaml`
- 9 tests covering all five engines, shape validation, configured/unconfigured states

## Test plan

- [ ] 95 tests pass
- [ ] `GET /v1/models` returns 200 with `engines` list
- [ ] Each engine has `engine`, `configured`, `default`, `models` fields
- [ ] `configured` reflects whether the API key env var is set
- [ ] LiteLLM entry includes `note` field