### PR TITLE
refactor: standardize error responses with api/errors.py helpers

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,41 @@
+"""Centralized error response helpers for consistent API error shapes."""
+
+from __future__ import annotations
+
+from flask import jsonify
+
+
+def error_response(message: str, status: int, code: str | None = None):
+    """Return a JSON error response with a consistent shape.
+
+    All API errors have at minimum: {"error": "..."}
+    When a machine-readable code is provided: {"error": "...", "code": "..."}
+    """
+    body = {"error": message}
+    if code:
+        body["code"] = code
+    return jsonify(body), status
+
+
+def bad_request(message: str, code: str | None = None):
+    return error_response(message, 400, code)
+
+
+def unauthorized(message: str = "Authentication failed", code: str | None = None):
+    return error_response(message, 401, code)
+
+
+def not_found(message: str, code: str | None = None):
+    return error_response(message, 404, code)
+
+
+def rate_limited(message: str = "Rate limit exceeded", code: str | None = None):
+    return error_response(message, 429, code)
+
+
+def gateway_timeout(message: str = "Upstream request timed out", code: str | None = None):
+    return error_response(message, 504, code)
+
+
+def internal_error(message: str = "An unexpected error occurred", code: str | None = None):
+    return error_response(message, 500, code)

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -4,6 +4,7 @@ import os
 from openai import OpenAI
 from api.llm_providers import generate_gemini_content
 from api.validation import get_json_body
+from api.errors import bad_request, unauthorized, not_found, rate_limited, gateway_timeout, internal_error
 
 code_generation_bp = Blueprint('code_generation', __name__)
 
@@ -42,13 +43,14 @@ def generate_code():
     engine = body.get("engine", "openai")
 
     if not isinstance(engine, str) or engine not in ENGINE_DEFAULTS:
-        return jsonify({
-            "error": f"Invalid engine. Must be one of: {', '.join(ENGINE_DEFAULTS.keys())}"
-        }), 400
+        return bad_request(
+            f"Invalid engine. Must be one of: {', '.join(ENGINE_DEFAULTS.keys())}",
+            code="invalid_engine",
+        )
 
     model = body.get("model", ENGINE_DEFAULTS[engine])
     if model is not None and not isinstance(model, str):
-        return jsonify({"error": "'model' must be a string"}), 400
+        return bad_request("'model' must be a string", code="invalid_model")
 
     general_system_prompt = """
 You are an assistant that knows about Manim. Manim is a mathematical animation engine that is used to create videos programmatically.
@@ -95,16 +97,19 @@ def construct(self):
             code = response.choices[0].message.content
             return jsonify({"code": code})
 
-        except AuthenticationError as e:
-            return jsonify({"error": f"LiteLLM auth failed (check API key): {e}"}), 401
-        except NotFoundError as e:
-            return jsonify({"error": f"LiteLLM model not found (use provider/model format, e.g. openai/gpt-4o): {e}"}), 404
-        except RateLimitError as e:
-            return jsonify({"error": f"LiteLLM rate limit exceeded: {e}"}), 429
-        except Timeout as e:
-            return jsonify({"error": f"LiteLLM request timed out: {e}"}), 504
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except AuthenticationError:
+            return unauthorized("Authentication failed — check LITELLM_API_KEY", code="auth_failed")
+        except NotFoundError:
+            return not_found(
+                "Model not found — use provider/model format (e.g. openai/gpt-4o)",
+                code="model_not_found",
+            )
+        except RateLimitError:
+            return rate_limited("LiteLLM rate limit exceeded", code="rate_limited")
+        except Timeout:
+            return gateway_timeout("LiteLLM request timed out", code="timeout")
+        except Exception:
+            return internal_error(code="litellm_error")
 
     elif engine == "anthropic" or model.startswith("claude-"):
         client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
@@ -118,20 +123,18 @@ def construct(self):
                 messages=messages,
             )
 
-            # Extract the text content from the response
             code = "".join(block.text for block in response.content)
-
             return jsonify({"code": code})
 
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error(code="anthropic_error")
 
     elif engine == "gemini" or model.startswith("gemini-"):
         try:
             code = generate_gemini_content(model, general_system_prompt, prompt_content)
             return jsonify({"code": code})
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error(code="gemini_error")
 
     else:
         messages = [
@@ -148,8 +151,7 @@ def construct(self):
             )
 
             code = response.choices[0].message.content
-
             return jsonify({"code": code})
 
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error(code="openai_error")

--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -7,6 +7,7 @@ import uuid
 from openai import OpenAI
 from api.llm_providers import generate_gemini_content
 from api.validation import get_json_body, require_string, validate_aspect_ratio
+from api.errors import internal_error, gateway_timeout
 
 video_generation_bp = Blueprint('video_generation', __name__)
 
@@ -125,8 +126,8 @@ def generate_video():
         try:
             code = generate_manim_code(prompt, engine, model)
             print(f"Code generation successful")
-        except Exception as e:
-            return jsonify({"error": f"Code generation failed: {str(e)}"}), 500
+        except Exception:
+            return internal_error("Code generation failed", code="code_generation_failed")
 
         # Step 2: Render the video
         print(f"Step 2: Rendering video")
@@ -172,8 +173,7 @@ config.frame_width = {frame_width}
             )
 
             if result.returncode != 0:
-                error_msg = result.stderr or result.stdout
-                return jsonify({"error": f"Manim rendering failed: {error_msg}"}), 500
+                return internal_error("Manim rendering failed", code="render_failed")
 
             # Find the generated video file
             video_file_path = os.path.join(
@@ -182,7 +182,7 @@ config.frame_width = {frame_width}
             )
 
             if not os.path.exists(video_file_path):
-                return jsonify({"error": "Video file not found after rendering"}), 500
+                return internal_error("Video file not found after rendering", code="video_not_found")
 
             # Move video to public folder
             video_storage_file_name = f"video-{user_id}-{project_name}-{iteration}"
@@ -205,9 +205,9 @@ config.frame_width = {frame_width}
             }), 200
 
         except subprocess.TimeoutExpired:
-            return jsonify({"error": "Video rendering timed out"}), 500
-        except Exception as e:
-            return jsonify({"error": f"Video rendering failed: {str(e)}"}), 500
+            return gateway_timeout("Video rendering timed out", code="render_timeout")
+        except Exception:
+            return internal_error("Video rendering failed", code="render_error")
         finally:
             # Cleanup temporary files
             try:
@@ -215,9 +215,8 @@ config.frame_width = {frame_width}
                     os.remove(file_path)
                 if os.path.exists(video_file_path):
                     os.remove(video_file_path)
-            except:
+            except Exception:
                 pass
 
-    except Exception as e:
-        print(f"Unexpected error: {str(e)}")
-        return jsonify({"error": f"Unexpected error: {str(e)}"}), 500
+    except Exception:
+        return internal_error(code="unexpected_error")

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -238,14 +238,16 @@ class TestCodeGenerationLiteLLMEdgeCases:
         assert resp.status_code == 500
 
     def test_context_length_exceeded(self, client):
-        """Token limit / context window overflow returns 500."""
+        """Token limit / context window overflow returns 500 with sanitized error."""
         _fake_litellm.completion.side_effect = RuntimeError("context_length_exceeded")
         resp = client.post("/v1/code/generation", json={
             "prompt": "test",
             "engine": "litellm",
         })
         assert resp.status_code == 500
-        assert "context_length" in resp.get_json()["error"]
+        data = resp.get_json()
+        assert "error" in data
+        assert data.get("code") == "litellm_error"
 
 
 class TestChatGenerationLiteLLMEngine:

--- a/tests/test_video_generation.py
+++ b/tests/test_video_generation.py
@@ -146,7 +146,7 @@ class TestVideoGenerationOpenAI:
                     "engine": "openai",
                 })
 
-        assert resp.status_code == 500
+        assert resp.status_code == 504
         assert "timed out" in resp.get_json()["error"].lower()
 
 


### PR DESCRIPTION
## Summary

- Adds `api/errors.py` with typed helpers: `bad_request`, `unauthorized`, `not_found`, `rate_limited`, `gateway_timeout`, `internal_error`
- Each helper accepts an optional `code` field for machine-readable error classification
- Updates `code_generation.py`: removes raw exception messages from responses; LiteLLM errors now return typed codes (`litellm_error`, `auth_failed`, `model_not_found`, etc.)
- Updates `video_generation.py`: render timeout now correctly returns 504 instead of 500; removes exception message leakage
- Updates affected tests to match new status codes and sanitized error shapes

## Test plan

- [ ] 95 tests pass
- [ ] LiteLLM auth failure returns 401 with `"code": "auth_failed"`
- [ ] LiteLLM timeout returns 504 with `"code": "timeout"`
- [ ] Video render timeout returns 504 with `"code": "render_timeout"`
- [ ] Internal errors return `"An unexpected error occurred"` without leaking stack traces