### PR TITLE
refactor: API polish, dedup shared code, expand test coverage

### DIFF
--- a/api/prompts/system.py
+++ b/api/prompts/system.py
@@ -1,0 +1,20 @@
+"""Shared system prompts used across code and video generation routes."""
+
+MANIM_CODE_GENERATION_PROMPT = (
+    "You are an assistant that knows about Manim. Manim is a mathematical animation engine"
+    " that is used to create videos programmatically.\n\n"
+    "The following is an example of the code:\n"
+    "```\n"
+    "from manim import *\n"
+    "from math import *\n\n"
+    "class GenScene(Scene):\n"
+    "    def construct(self):\n"
+    "        c = Circle(color=BLUE)\n"
+    "        self.play(Create(c))\n\n"
+    "```\n\n"
+    "# Rules\n"
+    "1. Always use GenScene as the class name, otherwise, the code will not work.\n"
+    "2. Always use self.play() to play the animation, otherwise, the code will not work.\n"
+    "3. Do not use text to explain the code, only the code.\n"
+    "4. Do not explain the code, only the code."
+)

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -98,10 +98,10 @@ def construct(self):
             return jsonify({"code": code})
 
         except AuthenticationError:
-            return unauthorized("Authentication failed — check LITELLM_API_KEY", code="auth_failed")
+            return unauthorized("Authentication failed: check LITELLM_API_KEY", code="auth_failed")
         except NotFoundError:
             return not_found(
-                "Model not found — use provider/model format (e.g. openai/gpt-4o)",
+                "Model not found: use provider/model format (e.g. openai/gpt-4o)",
                 code="model_not_found",
             )
         except RateLimitError:

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -3,6 +3,7 @@ import anthropic
 import os
 from openai import OpenAI
 from api.llm_providers import generate_gemini_content
+from api.prompts.system import MANIM_CODE_GENERATION_PROMPT
 from api.validation import get_json_body
 from api.errors import bad_request, unauthorized, not_found, rate_limited, gateway_timeout, internal_error
 
@@ -52,27 +53,7 @@ def generate_code():
     if model is not None and not isinstance(model, str):
         return bad_request("'model' must be a string", code="invalid_model")
 
-    general_system_prompt = """
-You are an assistant that knows about Manim. Manim is a mathematical animation engine that is used to create videos programmatically.
-
-The following is an example of the code:
-\`\`\`
-from manim import *
-from math import *
-
-class GenScene(Scene):
-def construct(self):
-    c = Circle(color=BLUE)
-    self.play(Create(c))
-
-\`\`\`
-
-# Rules
-1. Always use GenScene as the class name, otherwise, the code will not work.
-2. Always use self.play() to play the animation, otherwise, the code will not work.
-3. Do not use text to explain the code, only the code.
-4. Do not explain the code, only the code.
-    """
+    general_system_prompt = MANIM_CODE_GENERATION_PROMPT
 
     if engine == "litellm":
         import litellm

--- a/api/routes/models.py
+++ b/api/routes/models.py
@@ -10,17 +10,17 @@ _ENGINES = {
         "env_var": "OPENAI_API_KEY",
         "default": "gpt-4o",
         "models": [
-            {"id": "gpt-4o", "description": "GPT-4o — OpenAI's latest multimodal model"},
-            {"id": "o1-mini", "description": "o1-mini — compact reasoning model"},
+            {"id": "gpt-4o", "description": "GPT-4o: OpenAI's latest multimodal model"},
+            {"id": "o1-mini", "description": "o1-mini: compact reasoning model"},
         ],
     },
     "anthropic": {
         "env_var": "ANTHROPIC_API_KEY",
         "default": "claude-sonnet-4-6",
         "models": [
-            {"id": "claude-sonnet-4-6", "description": "Claude Sonnet 4.6 — balanced speed and quality"},
-            {"id": "claude-opus-4-7", "description": "Claude Opus 4.7 — highest capability"},
-            {"id": "claude-haiku-4-5-20251001", "description": "Claude Haiku 4.5 — fastest and most compact"},
+            {"id": "claude-sonnet-4-6", "description": "Claude Sonnet 4.6: balanced speed and quality"},
+            {"id": "claude-opus-4-7", "description": "Claude Opus 4.7: highest capability"},
+            {"id": "claude-haiku-4-5-20251001", "description": "Claude Haiku 4.5: fastest and most compact"},
             {"id": "claude-3-5-sonnet-20241022", "description": "Claude 3.5 Sonnet (legacy)"},
         ],
     },
@@ -28,8 +28,8 @@ _ENGINES = {
         "env_var": "GEMINI_API_KEY",
         "default": "gemini-2.5-flash",
         "models": [
-            {"id": "gemini-2.5-flash", "description": "Gemini 2.5 Flash — fast and efficient"},
-            {"id": "gemini-2.5-pro", "description": "Gemini 2.5 Pro — highest capability"},
+            {"id": "gemini-2.5-flash", "description": "Gemini 2.5 Flash: fast and efficient"},
+            {"id": "gemini-2.5-pro", "description": "Gemini 2.5 Pro: highest capability"},
         ],
     },
     "featherless": {

--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -9,18 +9,9 @@ from api.llm_providers import generate_gemini_content
 from api.prompts.system import MANIM_CODE_GENERATION_PROMPT
 from api.validation import get_json_body, require_string, validate_aspect_ratio
 from api.errors import internal_error, gateway_timeout
+from api.video_utils import get_frame_config
 
 video_generation_bp = Blueprint('video_generation', __name__)
-
-def get_frame_config(aspect_ratio):
-    if aspect_ratio == "16:9":
-        return (3840, 2160), 14.22
-    elif aspect_ratio == "9:16":
-        return (1080, 1920), 8.0
-    elif aspect_ratio == "1:1":
-        return (1080, 1080), 8.0
-    else:
-        return (3840, 2160), 14.22
 
 
 def generate_manim_code(prompt, engine="openai", model="gpt-4o"):

--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -6,32 +6,11 @@ import subprocess
 import uuid
 from openai import OpenAI
 from api.llm_providers import generate_gemini_content
+from api.prompts.system import MANIM_CODE_GENERATION_PROMPT
 from api.validation import get_json_body, require_string, validate_aspect_ratio
 from api.errors import internal_error, gateway_timeout
 
 video_generation_bp = Blueprint('video_generation', __name__)
-
-CODE_GENERATION_SYSTEM_PROMPT = """
-You are an assistant that knows about Manim. Manim is a mathematical animation engine that is used to create videos programmatically.
-
-The following is an example of the code:
-\`\`\`
-from manim import *
-from math import *
-
-class GenScene(Scene):
-    def construct(self):
-        c = Circle(color=BLUE)
-        self.play(Create(c))
-
-\`\`\`
-
-# Rules
-1. Always use GenScene as the class name, otherwise, the code will not work.
-2. Always use self.play() to play the animation, otherwise, the code will not work.
-3. Do not use text to explain the code, only the code.
-4. Do not explain the code, only the code.
-"""
 
 def get_frame_config(aspect_ratio):
     if aspect_ratio == "16:9":
@@ -54,7 +33,7 @@ def generate_manim_code(prompt, engine="openai", model="gpt-4o"):
                 model=model,
                 max_tokens=1000,
                 temperature=0.2,
-                system=CODE_GENERATION_SYSTEM_PROMPT,
+                system=MANIM_CODE_GENERATION_PROMPT,
                 messages=messages,
             )
             code = "".join(block.text for block in response.content)
@@ -63,13 +42,13 @@ def generate_manim_code(prompt, engine="openai", model="gpt-4o"):
             raise Exception(f"Error generating code with {model}: {str(e)}")
     elif engine == "gemini" or model.startswith("gemini-"):
         try:
-            return generate_gemini_content(model, CODE_GENERATION_SYSTEM_PROMPT, prompt)
+            return generate_gemini_content(model, MANIM_CODE_GENERATION_PROMPT, prompt)
         except Exception as e:
             raise Exception(f"Error generating code with {model}: {str(e)}")
     else:
         client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         messages = [
-            {"role": "system", "content": CODE_GENERATION_SYSTEM_PROMPT},
+            {"role": "system", "content": MANIM_CODE_GENERATION_PROMPT},
             {"role": "user", "content": prompt},
         ]
         try:

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -12,6 +12,7 @@ import uuid
 import time
 import requests
 from api.validation import get_json_body, require_string, validate_aspect_ratio, validate_boolean
+from api.video_utils import get_frame_config
 
 video_rendering_bp = Blueprint("video_rendering", __name__)
 
@@ -62,17 +63,6 @@ def move_to_public_folder(
     url_base = base_url if base_url else BASE_URL
     video_url = f"{url_base.rstrip('/')}/public/{new_file_name}"
     return video_url
-
-
-def get_frame_config(aspect_ratio):
-    if aspect_ratio == "16:9":
-        return (3840, 2160), 14.22
-    elif aspect_ratio == "9:16":
-        return (1080, 1920), 8.0
-    elif aspect_ratio == "1:1":
-        return (1080, 1080), 8.0
-    else:
-        return (3840, 2160), 14.22
 
 
 @video_rendering_bp.route("/v1/video/rendering", methods=["POST"])

--- a/api/video_utils.py
+++ b/api/video_utils.py
@@ -1,0 +1,12 @@
+"""Shared utilities for video generation and rendering routes."""
+
+from typing import Tuple
+
+
+def get_frame_config(aspect_ratio: str) -> Tuple[Tuple[int, int], float]:
+    """Return (frame_size, frame_width) for a given aspect ratio string."""
+    if aspect_ratio == "9:16":
+        return (1080, 1920), 8.0
+    if aspect_ratio == "1:1":
+        return (1080, 1080), 8.0
+    return (3840, 2160), 14.22

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared pytest fixtures and stubs for the generative-manim test suite."""
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+def _install_litellm_stub():
+    """Register a fake litellm module so app imports don't require the real package."""
+    if "litellm" in sys.modules:
+        return
+
+    fake_litellm = types.ModuleType("litellm")
+    fake_exceptions = types.ModuleType("litellm.exceptions")
+
+    class _AuthenticationError(Exception):
+        pass
+
+    class _NotFoundError(Exception):
+        pass
+
+    class _RateLimitError(Exception):
+        pass
+
+    class _Timeout(Exception):
+        pass
+
+    fake_exceptions.AuthenticationError = _AuthenticationError
+    fake_exceptions.NotFoundError = _NotFoundError
+    fake_exceptions.RateLimitError = _RateLimitError
+    fake_exceptions.Timeout = _Timeout
+    fake_litellm.exceptions = fake_exceptions
+    fake_litellm.completion = mock.MagicMock()
+
+    sys.modules["litellm"] = fake_litellm
+    sys.modules["litellm.exceptions"] = fake_exceptions
+
+
+_install_litellm_stub()
+
+
+@pytest.fixture
+def app():
+    sys.path.insert(0, ".")
+    from api.run import app as flask_app
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,136 @@
+"""Unit tests for api/errors.py response helpers."""
+
+import pytest
+
+
+class TestErrorResponse:
+    def test_returns_json_with_error_field(self, client):
+        from api.errors import error_response
+        with client.application.test_request_context():
+            resp, status = error_response("something broke", 500)
+        assert status == 500
+        assert resp.get_json()["error"] == "something broke"
+
+    def test_includes_code_when_provided(self, client):
+        from api.errors import error_response
+        with client.application.test_request_context():
+            resp, status = error_response("oops", 400, code="bad_thing")
+        data = resp.get_json()
+        assert data["code"] == "bad_thing"
+        assert data["error"] == "oops"
+
+    def test_omits_code_when_none(self, client):
+        from api.errors import error_response
+        with client.application.test_request_context():
+            resp, _ = error_response("oops", 400)
+        assert "code" not in resp.get_json()
+
+
+class TestBadRequest:
+    def test_status_400(self, client):
+        from api.errors import bad_request
+        with client.application.test_request_context():
+            _, status = bad_request("bad input")
+        assert status == 400
+
+    def test_message_in_body(self, client):
+        from api.errors import bad_request
+        with client.application.test_request_context():
+            resp, _ = bad_request("bad input")
+        assert resp.get_json()["error"] == "bad input"
+
+    def test_optional_code(self, client):
+        from api.errors import bad_request
+        with client.application.test_request_context():
+            resp, _ = bad_request("bad input", code="invalid_field")
+        assert resp.get_json()["code"] == "invalid_field"
+
+
+class TestUnauthorized:
+    def test_status_401(self, client):
+        from api.errors import unauthorized
+        with client.application.test_request_context():
+            _, status = unauthorized()
+        assert status == 401
+
+    def test_default_message(self, client):
+        from api.errors import unauthorized
+        with client.application.test_request_context():
+            resp, _ = unauthorized()
+        assert "authentication" in resp.get_json()["error"].lower()
+
+    def test_custom_message(self, client):
+        from api.errors import unauthorized
+        with client.application.test_request_context():
+            resp, _ = unauthorized("token expired")
+        assert resp.get_json()["error"] == "token expired"
+
+
+class TestNotFound:
+    def test_status_404(self, client):
+        from api.errors import not_found
+        with client.application.test_request_context():
+            _, status = not_found("thing not found")
+        assert status == 404
+
+    def test_message_in_body(self, client):
+        from api.errors import not_found
+        with client.application.test_request_context():
+            resp, _ = not_found("model xyz missing")
+        assert resp.get_json()["error"] == "model xyz missing"
+
+
+class TestRateLimited:
+    def test_status_429(self, client):
+        from api.errors import rate_limited
+        with client.application.test_request_context():
+            _, status = rate_limited()
+        assert status == 429
+
+    def test_default_message(self, client):
+        from api.errors import rate_limited
+        with client.application.test_request_context():
+            resp, _ = rate_limited()
+        assert "rate" in resp.get_json()["error"].lower()
+
+
+class TestGatewayTimeout:
+    def test_status_504(self, client):
+        from api.errors import gateway_timeout
+        with client.application.test_request_context():
+            _, status = gateway_timeout()
+        assert status == 504
+
+    def test_default_message(self, client):
+        from api.errors import gateway_timeout
+        with client.application.test_request_context():
+            resp, _ = gateway_timeout()
+        assert "timed out" in resp.get_json()["error"].lower()
+
+    def test_custom_message(self, client):
+        from api.errors import gateway_timeout
+        with client.application.test_request_context():
+            resp, _ = gateway_timeout("render timed out")
+        assert resp.get_json()["error"] == "render timed out"
+
+
+class TestInternalError:
+    def test_status_500(self, client):
+        from api.errors import internal_error
+        with client.application.test_request_context():
+            _, status = internal_error()
+        assert status == 500
+
+    def test_default_message(self, client):
+        from api.errors import internal_error
+        with client.application.test_request_context():
+            resp, _ = internal_error()
+        assert "error" in resp.get_json()
+
+    def test_custom_message_and_code(self, client):
+        from api.errors import internal_error
+        with client.application.test_request_context():
+            resp, _ = internal_error("db exploded", code="db_error")
+        data = resp.get_json()
+        assert data["error"] == "db exploded"
+        assert data["code"] == "db_error"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,171 @@
+"""Unit tests for api/validation.py helpers."""
+
+import pytest
+
+
+class TestGetJsonBody:
+    def test_valid_json_returns_dict(self, client):
+        with client.application.test_request_context(
+            "/", method="POST", json={"key": "value"}
+        ):
+            from api.validation import get_json_body
+            body, err = get_json_body()
+        assert err is None
+        assert body == {"key": "value"}
+
+    def test_missing_body_returns_error(self, client):
+        with client.application.test_request_context(
+            "/", method="POST", content_type="application/json", data=""
+        ):
+            from api.validation import get_json_body
+            body, err = get_json_body()
+        assert body is None
+        assert err is not None
+
+    def test_non_object_json_returns_error(self, client):
+        with client.application.test_request_context(
+            "/", method="POST", content_type="application/json", data="[1, 2, 3]"
+        ):
+            from api.validation import get_json_body
+            body, err = get_json_body()
+        assert body is None
+        assert err is not None
+
+    def test_wrong_content_type_returns_error(self, client):
+        with client.application.test_request_context(
+            "/", method="POST", content_type="text/plain", data="hello"
+        ):
+            from api.validation import get_json_body
+            body, err = get_json_body()
+        assert body is None
+        assert err is not None
+
+
+class TestRequireString:
+    def test_valid_string_returned(self, client):
+        from api.validation import require_string
+        with client.application.test_request_context("/"):
+            value, err = require_string({"name": "hello"}, "name")
+        assert err is None
+        assert value == "hello"
+
+    def test_missing_field_returns_error(self, client):
+        from api.validation import require_string
+        with client.application.test_request_context("/"):
+            value, err = require_string({}, "name")
+        assert value is None
+        assert err is not None
+
+    def test_non_string_field_returns_error(self, client):
+        from api.validation import require_string
+        with client.application.test_request_context("/"):
+            value, err = require_string({"name": 42}, "name")
+        assert value is None
+        assert err is not None
+
+    def test_empty_string_returns_error_by_default(self, client):
+        from api.validation import require_string
+        with client.application.test_request_context("/"):
+            value, err = require_string({"name": "   "}, "name")
+        assert value is None
+        assert err is not None
+
+    def test_empty_string_allowed_with_flag(self, client):
+        from api.validation import require_string
+        with client.application.test_request_context("/"):
+            value, err = require_string({"name": ""}, "name", allow_empty=True)
+        assert err is None
+        assert value == ""
+
+    def test_error_references_field_name(self, client):
+        from api.validation import require_string
+        with client.application.test_request_context("/"):
+            _, (resp, _status) = require_string({}, "prompt")
+        assert "prompt" in resp.get_json()["error"]
+
+
+class TestValidateAspectRatio:
+    def test_valid_16x9(self, client):
+        from api.validation import validate_aspect_ratio
+        with client.application.test_request_context("/"):
+            value, err = validate_aspect_ratio({"aspect_ratio": "16:9"})
+        assert err is None
+        assert value == "16:9"
+
+    def test_valid_9x16(self, client):
+        from api.validation import validate_aspect_ratio
+        with client.application.test_request_context("/"):
+            value, err = validate_aspect_ratio({"aspect_ratio": "9:16"})
+        assert err is None
+        assert value == "9:16"
+
+    def test_valid_1x1(self, client):
+        from api.validation import validate_aspect_ratio
+        with client.application.test_request_context("/"):
+            value, err = validate_aspect_ratio({"aspect_ratio": "1:1"})
+        assert err is None
+        assert value == "1:1"
+
+    def test_missing_uses_default(self, client):
+        from api.validation import validate_aspect_ratio
+        with client.application.test_request_context("/"):
+            value, err = validate_aspect_ratio({})
+        assert err is None
+        assert value == "16:9"
+
+    def test_invalid_ratio_returns_error(self, client):
+        from api.validation import validate_aspect_ratio
+        with client.application.test_request_context("/"):
+            value, err = validate_aspect_ratio({"aspect_ratio": "4:3"})
+        assert value is None
+        assert err is not None
+
+    def test_invalid_ratio_error_mentions_field(self, client):
+        from api.validation import validate_aspect_ratio
+        with client.application.test_request_context("/"):
+            _, (resp, _status) = validate_aspect_ratio({"aspect_ratio": "bad"})
+        assert "aspect_ratio" in resp.get_json()["error"]
+
+
+class TestValidateBoolean:
+    def test_true_accepted(self, client):
+        from api.validation import validate_boolean
+        with client.application.test_request_context("/"):
+            value, err = validate_boolean({"flag": True}, "flag")
+        assert err is None
+        assert value is True
+
+    def test_false_accepted(self, client):
+        from api.validation import validate_boolean
+        with client.application.test_request_context("/"):
+            value, err = validate_boolean({"flag": False}, "flag")
+        assert err is None
+        assert value is False
+
+    def test_missing_returns_default_false(self, client):
+        from api.validation import validate_boolean
+        with client.application.test_request_context("/"):
+            value, err = validate_boolean({}, "flag")
+        assert err is None
+        assert value is False
+
+    def test_missing_returns_custom_default(self, client):
+        from api.validation import validate_boolean
+        with client.application.test_request_context("/"):
+            value, err = validate_boolean({}, "flag", default=True)
+        assert err is None
+        assert value is True
+
+    def test_string_returns_error(self, client):
+        from api.validation import validate_boolean
+        with client.application.test_request_context("/"):
+            value, err = validate_boolean({"flag": "true"}, "flag")
+        assert value is None
+        assert err is not None
+
+    def test_integer_returns_error(self, client):
+        from api.validation import validate_boolean
+        with client.application.test_request_context("/"):
+            value, err = validate_boolean({"flag": 1}, "flag")
+        assert value is None
+        assert err is not None

--- a/tests/test_video_utils.py
+++ b/tests/test_video_utils.py
@@ -1,0 +1,29 @@
+"""Unit tests for api/video_utils.py."""
+
+from api.video_utils import get_frame_config
+
+
+class TestGetFrameConfig:
+    def test_16x9_returns_4k_resolution(self):
+        size, width = get_frame_config("16:9")
+        assert size == (3840, 2160)
+        assert width == 14.22
+
+    def test_9x16_returns_portrait_resolution(self):
+        size, width = get_frame_config("9:16")
+        assert size == (1080, 1920)
+        assert width == 8.0
+
+    def test_1x1_returns_square_resolution(self):
+        size, width = get_frame_config("1:1")
+        assert size == (1080, 1080)
+        assert width == 8.0
+
+    def test_unknown_ratio_falls_back_to_16x9(self):
+        size, width = get_frame_config("4:3")
+        assert size == (3840, 2160)
+        assert width == 14.22
+
+    def test_empty_string_falls_back_to_16x9(self):
+        size, width = get_frame_config("")
+        assert size == (3840, 2160)


### PR DESCRIPTION
## Summary

- Fix em-dashes in error messages and model descriptions (per project style)
- Extract shared Manim system prompt to `api/prompts/system.py`, eliminating duplication between code and video generation routes and fixing Python escape sequence warnings
- Extract duplicated `get_frame_config` to `api/video_utils.py` shared by both video routes
- Add `tests/conftest.py` with shared litellm stub to reduce boilerplate across test files
- Add 46 new unit tests covering `api/errors.py`, `api/validation.py`, and `api/video_utils.py`

Test count: 95 before, 141 after.

## Test plan

- [x] Full test suite passes: `141 passed, 1 warning`
- [x] No new warnings introduced (escape sequence DeprecationWarnings removed)
- [x] All refactored routes (code generation, video generation, video rendering) covered by existing + new tests