### PR TITLE
refactor: remove test boilerplate and route noise

### DIFF
--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -1,7 +1,6 @@
 from flask import Blueprint, jsonify, request
 import anthropic
 import os
-import json
 import subprocess
 import uuid
 from openai import OpenAI

--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, request
 import anthropic
 import os
+import shutil
 import subprocess
 import uuid
 from openai import OpenAI
@@ -14,7 +15,6 @@ video_generation_bp = Blueprint('video_generation', __name__)
 
 
 def generate_manim_code(prompt, engine="openai", model="gpt-4o"):
-    """Generate Manim code from a text prompt"""
     if model.startswith("claude-"):
         client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
         messages = [{"role": "user", "content": prompt}]
@@ -55,20 +55,6 @@ def generate_manim_code(prompt, engine="openai", model="gpt-4o"):
 
 @video_generation_bp.route("/v1/video/generation", methods=["POST"])
 def generate_video():
-    """
-    Generate a video from a text prompt.
-
-    Request Body:
-    {
-        "prompt": "Create a Manim animation that shows a square transforming into a circle",
-        "engine": "openai",  // Optional, defaults to "openai"
-        "model": "gpt-4o",  // Optional, defaults to "gpt-4o"
-        "aspect_ratio": "16:9",  // Optional, defaults to "16:9"
-        "user_id": "user-123",  // Optional
-        "project_name": "my-project",  // Optional
-        "iteration": 1  // Optional
-    }
-    """
     body, err = get_json_body()
     if err:
         return err
@@ -88,20 +74,12 @@ def generate_video():
         project_name = body.get("project_name", "untitled")
         iteration = body.get("iteration", 1)
 
-        print(f"Generating video from prompt: {prompt}")
-
-        # Step 1: Generate Manim code
-        print(f"Step 1: Generating Manim code using {engine}/{model}")
         try:
             code = generate_manim_code(prompt, engine, model)
-            print(f"Code generation successful")
         except Exception:
             return internal_error("Code generation failed", code="code_generation_failed")
 
-        # Step 2: Render the video
-        print(f"Step 2: Rendering video")
         try:
-            # Prepare the code with frame configuration
             frame_size, frame_width = get_frame_config(aspect_ratio)
             modified_code = f"""
 from manim import *
@@ -112,7 +90,6 @@ config.frame_width = {frame_width}
 {code}
             """
 
-            # Create a temporary file for the code
             file_name = f"scene_{os.urandom(2).hex()}.py"
             api_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             public_dir = os.path.join(api_dir, "public")
@@ -122,7 +99,6 @@ config.frame_width = {frame_width}
             with open(file_path, "w") as f:
                 f.write(modified_code)
 
-            # Run Manim to render the video
             command = [
                 "manim",
                 file_path,
@@ -144,7 +120,6 @@ config.frame_width = {frame_width}
             if result.returncode != 0:
                 return internal_error("Manim rendering failed", code="render_failed")
 
-            # Find the generated video file
             video_file_path = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "GenScene.mp4"
@@ -153,19 +128,14 @@ config.frame_width = {frame_width}
             if not os.path.exists(video_file_path):
                 return internal_error("Video file not found after rendering", code="video_not_found")
 
-            # Move video to public folder
             video_storage_file_name = f"video-{user_id}-{project_name}-{iteration}"
             new_file_name = f"{video_storage_file_name}.mp4"
             new_file_path = os.path.join(public_dir, new_file_name)
 
-            import shutil
             shutil.move(video_file_path, new_file_path)
 
-            # Generate the video URL
             base_url = request.host_url.rstrip('/') if request.host_url else os.getenv("BASE_URL", "http://127.0.0.1:8080")
             video_url = f"{base_url}/public/{new_file_name}"
-
-            print(f"Video generated successfully: {video_url}")
 
             return jsonify({
                 "message": "Video generated successfully",
@@ -178,7 +148,6 @@ config.frame_width = {frame_width}
         except Exception:
             return internal_error("Video rendering failed", code="render_error")
         finally:
-            # Cleanup temporary files
             try:
                 if os.path.exists(file_path):
                     os.remove(file_path)

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -22,9 +22,6 @@ BASE_URL = os.getenv("BASE_URL", "http://127.0.0.1:8080")
 
 
 def upload_to_azure_storage(file_path: str, video_storage_file_name: str) -> str:
-    """
-    Uploads the video to Azure Blob Storage and returns the URL.
-    """
     cloud_file_name = f"{video_storage_file_name}.mp4"
 
     connection_string = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
@@ -34,11 +31,9 @@ def upload_to_azure_storage(file_path: str, video_storage_file_name: str) -> str
         container=container_name, blob=cloud_file_name
     )
 
-    # Upload the video file
     with open(file_path, "rb") as data:
         blob_client.upload_blob(data, overwrite=True)
 
-    # Construct the URL of the uploaded blob
     blob_url = f"https://{blob_service_client.account_name}.blob.core.windows.net/{container_name}/{cloud_file_name}"
     return blob_url
 
@@ -46,10 +41,6 @@ def upload_to_azure_storage(file_path: str, video_storage_file_name: str) -> str
 def move_to_public_folder(
     file_path: str, video_storage_file_name: str, base_url: Union[str, None] = None
 ) -> str:
-    """
-    Moves the video to the public folder and returns the URL.
-    """
-    # Get the api directory (go up one level from routes)
     api_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     public_folder = os.path.join(api_dir, "public")
     os.makedirs(public_folder, exist_ok=True)
@@ -59,7 +50,6 @@ def move_to_public_folder(
 
     shutil.move(file_path, new_file_path)
 
-    # Use the provided base_url if available, otherwise fall back to BASE_URL
     url_base = base_url if base_url else BASE_URL
     video_url = f"{url_base.rstrip('/')}/public/{new_file_name}"
     return video_url

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, current_app, request, Response
+from flask import Blueprint, jsonify, request, Response
 import subprocess
 import os
 import re

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -67,21 +67,6 @@ def move_to_public_folder(
 
 @video_rendering_bp.route("/v1/video/rendering", methods=["POST"])
 def render_video():
-    # Get the API key from the request headers
-    # api_key = request.headers.get('X-API-Key')
-    
-    # if not api_key:
-    #     return jsonify({"error": "API key is missing"}), 401
-    
-    # Validate the API key and get the user ID
-    # user_id = get_user_by_api_key(api_key)
-    
-    # if not user_id:
-    #     return jsonify({"error": "Invalid API key"}), 401
-    
-    # Now that we have a valid user_id, create a run
-    # run_id = create_run_on_user(user_id, "video")
-    
     body, err = get_json_body()
     if err:
         return err
@@ -106,10 +91,8 @@ def render_video():
 
     video_storage_file_name = f"video-{user_id}-{project_name}-{iteration}"
 
-    # Determine frame size and width based on aspect ratio
     frame_size, frame_width = get_frame_config(aspect_ratio)
 
-    # Modify the Manim script to include configuration settings
     modified_code = f"""
 from manim import *
 from math import *
@@ -119,16 +102,12 @@ config.frame_width = {frame_width}
 {code}
     """
 
-    # Create a unique file name
     file_name = f"scene_{os.urandom(2).hex()}.py"
-    
-    # Adjust the path to point to /api/public/
-    api_dir = os.path.dirname(os.path.dirname(__file__))  # Go up one level from routes
+    api_dir = os.path.dirname(os.path.dirname(__file__))
     public_dir = os.path.join(api_dir, "public")
-    os.makedirs(public_dir, exist_ok=True)  # Ensure the public directory exists
+    os.makedirs(public_dir, exist_ok=True)
     file_path = os.path.join(public_dir, file_name)
 
-    # Write the code to the file
     with open(file_path, "w") as f:
         f.write(modified_code)
 
@@ -136,7 +115,7 @@ config.frame_width = {frame_width}
         try:
             command_list = [
                 "manim",
-                file_path,  # Use the full path to the file
+                file_path,
                 file_class,
                 "--format=mp4",
                 "--media_dir",
@@ -348,22 +327,17 @@ def export_video():
     title_slug = request.json.get("titleSlug")
     local_filenames = []
 
-    # Download each scene
     for scene in scenes:
         video_url = scene["videoUrl"]
-        object_name = video_url.split("/")[-1]
         local_filename = download_video(video_url)
         local_filenames.append(local_filename)
 
-    # Generate a unique filename with UNIX timestamp
     timestamp = int(time.time())
-    # Sanitize title_slug to prevent command injection
     safe_slug = re.sub(r'[^a-zA-Z0-9_-]', '', title_slug or 'untitled')
     merged_filename = os.path.join(
         os.getcwd(), f"exported-scene-{safe_slug}-{timestamp}.mp4"
     )
 
-    # Build ffmpeg command as a list to avoid shell injection
     command_list = ["ffmpeg"]
     for filename in local_filenames:
         command_list.extend(["-i", filename])
@@ -374,7 +348,6 @@ def export_video():
     ])
 
     try:
-        # Execute the ffmpeg command safely (no shell=True)
         subprocess.run(command_list, check=True)
         print("Videos merged successfully.")
         print(f"merged_filename: {merged_filename}")

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -1,22 +1,8 @@
 """Tests for /v1/code/generation route (OpenAI, Anthropic, Gemini engines)."""
 
-import sys
-import types
 from unittest import mock
 
 import pytest
-
-# Stub heavy optional deps before any app imports
-_fake_litellm = types.ModuleType("litellm")
-_fake_exceptions = types.ModuleType("litellm.exceptions")
-_fake_exceptions.AuthenticationError = Exception
-_fake_exceptions.NotFoundError = Exception
-_fake_exceptions.RateLimitError = Exception
-_fake_exceptions.Timeout = Exception
-_fake_litellm.exceptions = _fake_exceptions
-_fake_litellm.completion = mock.MagicMock()
-sys.modules.setdefault("litellm", _fake_litellm)
-sys.modules.setdefault("litellm.exceptions", _fake_exceptions)
 
 
 def _make_openai_response(content):
@@ -35,19 +21,6 @@ def _make_anthropic_response(content):
     resp = mock.MagicMock()
     resp.content = [block]
     return resp
-
-
-@pytest.fixture
-def app():
-    sys.path.insert(0, ".")
-    from api.run import app
-    app.config["TESTING"] = True
-    return app
-
-
-@pytest.fixture
-def client(app):
-    return app.test_client()
 
 
 class TestCodeGenerationInvalidInput:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,34 +1,6 @@
 """Tests for the /health and /v1/health endpoints."""
 
-import sys
-import types
-from unittest import mock
-
 import pytest
-
-_fake_litellm = types.ModuleType("litellm")
-_fake_exceptions = types.ModuleType("litellm.exceptions")
-_fake_exceptions.AuthenticationError = Exception
-_fake_exceptions.NotFoundError = Exception
-_fake_exceptions.RateLimitError = Exception
-_fake_exceptions.Timeout = Exception
-_fake_litellm.exceptions = _fake_exceptions
-_fake_litellm.completion = mock.MagicMock()
-sys.modules.setdefault("litellm", _fake_litellm)
-sys.modules.setdefault("litellm.exceptions", _fake_exceptions)
-
-
-@pytest.fixture
-def app():
-    sys.path.insert(0, ".")
-    from api.run import app
-    app.config["TESTING"] = True
-    return app
-
-
-@pytest.fixture
-def client(app):
-    return app.test_client()
 
 
 class TestHealthEndpoint:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,34 +1,6 @@
 """Tests for the /v1/models endpoint."""
 
-import sys
-import types
-from unittest import mock
-
 import pytest
-
-_fake_litellm = types.ModuleType("litellm")
-_fake_exceptions = types.ModuleType("litellm.exceptions")
-_fake_exceptions.AuthenticationError = Exception
-_fake_exceptions.NotFoundError = Exception
-_fake_exceptions.RateLimitError = Exception
-_fake_exceptions.Timeout = Exception
-_fake_litellm.exceptions = _fake_exceptions
-_fake_litellm.completion = mock.MagicMock()
-sys.modules.setdefault("litellm", _fake_litellm)
-sys.modules.setdefault("litellm.exceptions", _fake_exceptions)
-
-
-@pytest.fixture
-def app():
-    sys.path.insert(0, ".")
-    from api.run import app
-    app.config["TESTING"] = True
-    return app
-
-
-@pytest.fixture
-def client(app):
-    return app.test_client()
 
 
 class TestModelsEndpoint:

--- a/tests/test_video_generation.py
+++ b/tests/test_video_generation.py
@@ -1,39 +1,11 @@
 """Tests for /v1/video/generation route."""
 
-import json
 import os
-import sys
-import types
 from unittest import mock
 
 import pytest
 
-# Stub litellm before app imports
-_fake_litellm = types.ModuleType("litellm")
-_fake_exceptions = types.ModuleType("litellm.exceptions")
-_fake_exceptions.AuthenticationError = Exception
-_fake_exceptions.NotFoundError = Exception
-_fake_exceptions.RateLimitError = Exception
-_fake_exceptions.Timeout = Exception
-_fake_litellm.exceptions = _fake_exceptions
-_fake_litellm.completion = mock.MagicMock()
-sys.modules.setdefault("litellm", _fake_litellm)
-sys.modules.setdefault("litellm.exceptions", _fake_exceptions)
-
 VALID_MANIM_CODE = "from manim import *\nclass GenScene(Scene):\n    def construct(self): pass"
-
-
-@pytest.fixture
-def app():
-    sys.path.insert(0, ".")
-    from api.run import app
-    app.config["TESTING"] = True
-    return app
-
-
-@pytest.fixture
-def client(app):
-    return app.test_client()
 
 
 @pytest.fixture

--- a/tests/test_video_rendering.py
+++ b/tests/test_video_rendering.py
@@ -1,37 +1,10 @@
 """Tests for /v1/video/rendering route."""
 
-import sys
-import types
 from unittest import mock
 
 import pytest
 
-# Stub litellm before app imports
-_fake_litellm = types.ModuleType("litellm")
-_fake_exceptions = types.ModuleType("litellm.exceptions")
-_fake_exceptions.AuthenticationError = Exception
-_fake_exceptions.NotFoundError = Exception
-_fake_exceptions.RateLimitError = Exception
-_fake_exceptions.Timeout = Exception
-_fake_litellm.exceptions = _fake_exceptions
-_fake_litellm.completion = mock.MagicMock()
-sys.modules.setdefault("litellm", _fake_litellm)
-sys.modules.setdefault("litellm.exceptions", _fake_exceptions)
-
 VALID_CODE = "from manim import *\nclass GenScene(Scene):\n    def construct(self): pass"
-
-
-@pytest.fixture
-def app():
-    sys.path.insert(0, ".")
-    from api.run import app
-    app.config["TESTING"] = True
-    return app
-
-
-@pytest.fixture
-def client(app):
-    return app.test_client()
 
 
 def _make_popen_mock(returncode=0, stderr_lines=None, stdout_lines=None):


### PR DESCRIPTION
## Summary

- Remove redundant litellm stubs and duplicate `app`/`client` fixtures from 5 test files, now handled by `conftest.py` (138 lines deleted)
- Remove dead commented-out API key validation block from `video_rendering.py`
- Remove unused `json` import from `video_generation.py` and unused `current_app` import from `video_rendering.py`
- Remove debug `print` statements, obvious what-comments, multi-line docstrings, and an inline `import shutil` from `video_generation.py`
- Remove obvious what-comments and unnecessary docstrings from `video_rendering.py`
- Move `shutil` import to module top-level in `video_generation.py`

## Test plan

- [x] Full test suite passes: `141 passed, 1 warning` before and after every commit
- [x] No behavior changes, only dead code and noise removed