### PR TITLE
fix: resolve CI lint failures and add pangocairo system dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Install system dependencies
+        run: sudo apt-get install -y libpango1.0-dev
+
       - name: Install dependencies
         run: |
           pip install -r api/requirements.txt -r requirements-dev.txt

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,15 +1,17 @@
 import os
+
+from dotenv import load_dotenv
 from flask import Flask, jsonify, send_from_directory
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from dotenv import load_dotenv
-from .routes.video_rendering import video_rendering_bp
-from .routes.code_generation import code_generation_bp
+
 from .routes.chat_generation import chat_generation_bp
-from .routes.video_generation import video_generation_bp
+from .routes.code_generation import code_generation_bp
 from .routes.health import health_bp
 from .routes.models import models_bp
+from .routes.video_generation import video_generation_bp
+from .routes.video_rendering import video_rendering_bp
 
 _DEFAULT_LIMITS = ["60 per minute", "500 per hour"]
 

--- a/api/prompts/manimDocs.py
+++ b/api/prompts/manimDocs.py
@@ -1,4 +1,4 @@
-manimDocs = """
+manimDocs = r"""
 ## Manim Index Documentation
 
 This reference list details modules, functions, and variables included in Manim, describing what they are and what they do.

--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -1,22 +1,23 @@
-from flask import Blueprint, jsonify, request, Response, stream_with_context
-import anthropic
-import openai
-import os
+import base64
+import io
 import json
-import subprocess
-import shutil
-import string
+import os
 import random
 import re
-import base64
-from api.prompts.manimDocs import manimDocs
-from api.llm_providers import generate_gemini_content_stream
-from api.validation import get_json_body
-from PIL import Image
-import io
+import shutil
+import string
+import subprocess
 import time
+
+import anthropic
+import openai
+from flask import Blueprint, Response, jsonify, request, stream_with_context
 from openai import APIError
-import uuid
+from PIL import Image
+
+from api.llm_providers import generate_gemini_content_stream
+from api.prompts.manimDocs import manimDocs
+from api.validation import get_json_body
 
 chat_generation_bp = Blueprint("chat_generation", __name__)
 
@@ -143,7 +144,7 @@ def _generate_manim_preview(code: str, class_name: str) -> str:
         f"--format=png --media_dir {temp_dir} --custom_folders -pql --disable_caching"
     )
     try:
-        result = subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+        subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
 
         previews_dir = os.path.join(api_dir, "public", "previews")
         os.makedirs(previews_dir, exist_ok=True)
@@ -206,13 +207,8 @@ def generate_code_chat():
 
     messages = data.get("messages", [])
     prompt = data.get("prompt")
-    global_prompt = data.get("globalPrompt", "")
-    user_id = data.get("userId") or f"user-{uuid.uuid4()}"
-    scenes = data.get("scenes", [])
-    project_title = data.get("projectTitle", "")
     engine = data.get("engine", "openai")
     model = data.get("model", None)
-    selected_scenes = data.get("selectedScenes", [])
     is_for_platform = data.get("isForPlatform", False)
 
     if engine not in _ENGINE_DEFAULTS:
@@ -229,7 +225,7 @@ def generate_code_chat():
     if not messages and prompt:
         messages = [{"role": "user", "content": prompt}]
 
-    general_system_prompt = """You are an assistant that creates animations with Manim. Manim is a mathematical animation engine that is used to create videos programmatically. You are running on Animo (www.animo.video), a tool to create videos with Manim.
+    general_system_prompt = r"""You are an assistant that creates animations with Manim. Manim is a mathematical animation engine that is used to create videos programmatically. You are running on Animo (www.animo.video), a tool to create videos with Manim.
 
 # What the user can do?
 
@@ -535,7 +531,6 @@ Rules:
                     
                     current_message = {"role": "assistant", "content": []}
                     current_text = ""
-                    json_buffer = ""
                     should_continue = False
                     tool_use_id = None
                     complete_json = ""
@@ -623,7 +618,7 @@ Rules:
                                             for char in preview_text:
                                                 escaped_char = repr(char)[1:-1]
                                                 yield f'0:"{escaped_char}"\n'
-                                            yield f'0:"[IMAGE: Preview frame]"\n'
+                                            yield '0:"[IMAGE: Preview frame]"\n'
                                         else:
                                             yield "\n[Preview frame]\n"
                                         
@@ -707,7 +702,7 @@ Rules:
                         
                         break
                     
-                    except APIError as e:
+                    except APIError:
                         if attempt < max_retries - 1:
                             time.sleep(retry_delay)
                         else:

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -1,11 +1,13 @@
-from flask import Blueprint, jsonify, request
-import anthropic
 import os
+
+import anthropic
+from flask import Blueprint, jsonify, request
 from openai import OpenAI
+
+from api.errors import bad_request, gateway_timeout, internal_error, not_found, rate_limited, unauthorized
 from api.llm_providers import generate_gemini_content
 from api.prompts.system import MANIM_CODE_GENERATION_PROMPT
 from api.validation import get_json_body
-from api.errors import bad_request, unauthorized, not_found, rate_limited, gateway_timeout, internal_error
 
 code_generation_bp = Blueprint('code_generation', __name__)
 

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,6 +1,7 @@
 """Health check endpoint for the Generative Manim API."""
 
 import os
+
 from flask import Blueprint, jsonify
 
 health_bp = Blueprint("health", __name__)

--- a/api/routes/models.py
+++ b/api/routes/models.py
@@ -1,6 +1,7 @@
 """List available models grouped by engine."""
 
 import os
+
 from flask import Blueprint, jsonify
 
 models_bp = Blueprint("models", __name__)

--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -1,14 +1,16 @@
-from flask import Blueprint, jsonify, request
-import anthropic
 import os
 import shutil
 import subprocess
 import uuid
+
+import anthropic
+from flask import Blueprint, jsonify, request
 from openai import OpenAI
+
+from api.errors import gateway_timeout, internal_error
 from api.llm_providers import generate_gemini_content
 from api.prompts.system import MANIM_CODE_GENERATION_PROMPT
 from api.validation import get_json_body, require_string, validate_aspect_ratio
-from api.errors import internal_error, gateway_timeout
 from api.video_utils import get_frame_config
 
 video_generation_bp = Blueprint('video_generation', __name__)

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -1,16 +1,18 @@
-from flask import Blueprint, jsonify, request, Response
-import subprocess
+import json
 import os
 import re
-import json
-import sys
-import traceback
-from azure.storage.blob import BlobServiceClient
 import shutil
-from typing import Union
-import uuid
+import subprocess
+import sys
 import time
+import traceback
+import uuid
+from typing import Union
+
 import requests
+from azure.storage.blob import BlobServiceClient
+from flask import Blueprint, Response, jsonify, request
+
 from api.validation import get_json_body, require_string, validate_aspect_ratio, validate_boolean
 from api.video_utils import get_frame_config
 

--- a/api/run.py
+++ b/api/run.py
@@ -1,4 +1,5 @@
 import os
+
 from api import create_app
 
 app = create_app()

--- a/api/validation.py
+++ b/api/validation.py
@@ -2,7 +2,6 @@
 
 from flask import jsonify, request
 
-
 VALID_ASPECT_RATIOS = {"16:9", "9:16", "1:1"}
 
 

--- a/tests/test_image_management.py
+++ b/tests/test_image_management.py
@@ -1,6 +1,7 @@
 """Unit tests for count_images_in_conversation and manage_conversation_images."""
 
 import pytest
+
 from api.routes.chat_generation import count_images_in_conversation, manage_conversation_images
 
 

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -13,11 +13,11 @@ _fake_google.genai = _fake_genai
 sys.modules.setdefault("google", _fake_google)
 sys.modules.setdefault("google.genai", _fake_genai)
 
-from api.llm_providers import (
+from api.llm_providers import (  # noqa: E402
+    GEMINI_MODEL_ALIASES,
+    generate_gemini_content,
     normalize_gemini_model,
     strip_markdown_code_fence,
-    generate_gemini_content,
-    GEMINI_MODEL_ALIASES,
 )
 
 


### PR DESCRIPTION
## Summary

- **Test job**: `manimpango` failed to build because `pangocairo` (`libpango1.0-dev`) was not installed on the CI runner. Added an `apt-get install` step before `pip install`.
- **Lint job**: 58 ruff errors across `api/` and `tests/`. Fixed all of them:
  - `I001` import ordering (all files, auto-fixed by ruff)
  - `W605` invalid escape sequences in `manimDocs.py` and `chat_generation.py`
  - `F841` unused local variables in `chat_generation.py` (`result`, `global_prompt`, `user_id`, `scenes`, `project_title`, `selected_scenes`, `json_buffer`, unused `uuid` import)
  - `E402` module-level import not at top in `test_llm_providers.py` (suppressed with `noqa`)

## Test plan

- [ ] CI Lint job passes
- [ ] CI Test job passes (pangocairo available, manimpango builds)
- [ ] Docker build job runs (unblocked by lint/test)