### PR TITLE
Add Manim skills comparison experiment (double pendulum)

### DIFF
--- a/experiments/manim-skills-comparison/README.md
+++ b/experiments/manim-skills-comparison/README.md
@@ -1,0 +1,33 @@
+# Comparación de skills de Manim para Claude Code
+
+Cuatro skills de Claude Code para generar animaciones con Manim, puestas a prueba con el mismo encargo: un video sobre el péndulo doble como ejemplo de teoría del caos.
+
+Origen de esta comparación: [r/manim - Best Manim skills comparison (with code + video)](https://www.reddit.com/r/manim/comments/1udub56/best_manim_skills_comparison_with_code_video/)
+
+## Skills comparados
+
+| Carpeta | Skill | Enfoque |
+|---|---|---|
+| `sin-skill/` | Ninguno (Manim base) | Una sola clase, patrón manual de `ValueTracker` + `updater`. |
+| `manim-composer/` | `manim-composer` | Planifica un arco narrativo (`scenes.md`) antes de escribir código. |
+| `manim-skill-yusuke/` | [yusuke710/manim-skill](https://github.com/yusuke710/manim-skill) | Una clase por escena, subtítulos nativos vía `add_subcaption()`, stitching con ffmpeg. |
+| `manim-video-affaan/` | [affaan-m/everything-claude-code (manim-video)](https://github.com/affaan-m/everything-claude-code) | Cada escena debe demostrar una sola idea (tesis visual). |
+
+Todos los scripts simulan el péndulo doble con el mismo integrador RK4 y los mismos parámetros físicos, para que la única variable real sea el flujo de trabajo de cada skill.
+
+Los videos resultantes y el análisis comparativo completo no se incluyen en este repositorio; este folder solo contiene el código fuente de las escenas (`Scene` classes de Manim) de cada skill.
+
+## Requisitos
+
+```bash
+pip install manim numpy
+```
+
+## Render
+
+```bash
+manim -pql sin-skill/double_pendulum.py DoublePendulumChaos
+manim -pql manim-composer/double_pendulum_v2.py DoublePendulumNarrative
+manim -pql manim-skill-yusuke/script.py Scene1_SinglePendulum  # y las demás Scene1-6
+manim -pql manim-video-affaan/script.py Scene1_SameStart        # y las demás Scene1-3
+```

--- a/experiments/manim-skills-comparison/manim-composer/double_pendulum_v2.py
+++ b/experiments/manim-skills-comparison/manim-composer/double_pendulum_v2.py
@@ -1,0 +1,236 @@
+from manim import *
+import numpy as np
+
+
+# ── Physics ────────────────────────────────────────────────────────────────────
+
+def rk4(f, y, t, dt, *args):
+    k1 = np.array(f(y, t, *args))
+    k2 = np.array(f(y + dt/2*k1, t+dt/2, *args))
+    k3 = np.array(f(y + dt/2*k2, t+dt/2, *args))
+    k4 = np.array(f(y + dt*k3,   t+dt,   *args))
+    return y + dt/6*(k1 + 2*k2 + 2*k3 + k4)
+
+
+def ode_simple(y, t, L, g):
+    return [y[1], -g/L*np.sin(y[0])]
+
+
+def ode_double(y, t, L1, L2, m1, m2, g):
+    th1, w1, th2, w2 = y
+    d = th2 - th1
+    D1 = (m1+m2)*L1 - m2*L1*np.cos(d)**2
+    D2 = L2/L1*D1
+    dw1 = (m2*L1*w1**2*np.sin(d)*np.cos(d) + m2*g*np.sin(th2)*np.cos(d)
+           + m2*L2*w2**2*np.sin(d) - (m1+m2)*g*np.sin(th1)) / D1
+    dw2 = (-m2*L2*w2**2*np.sin(d)*np.cos(d) + (m1+m2)*g*np.sin(th1)*np.cos(d)
+           - (m1+m2)*L1*w1**2*np.sin(d) - (m1+m2)*g*np.sin(th2)) / D2
+    return [w1, dw1, w2, dw2]
+
+
+def sim_simple(th0, steps, dt, L=2.0, g=9.8):
+    y = np.array([th0, 0.0])
+    out = []
+    for i in range(steps):
+        out.append((L*np.sin(y[0]), -L*np.cos(y[0])))
+        y = rk4(ode_simple, y, i*dt, dt, L, g)
+    return out
+
+
+def sim_double(th1, th2, steps, dt, L1=1.5, L2=1.2, g=9.8):
+    y = np.array([th1, 0.0, th2, 0.0])
+    out = []
+    for i in range(steps):
+        x1 = L1*np.sin(y[0]); y1 = -L1*np.cos(y[0])
+        x2 = x1+L2*np.sin(y[2]); y2 = y1-L2*np.cos(y[2])
+        out.append((x1, y1, x2, y2))
+        y = rk4(ode_double, y, i*dt, dt, L1, L2, 1.0, 1.0, g)
+    return out
+
+
+# ── Scene ──────────────────────────────────────────────────────────────────────
+
+class DoublePendulumNarrative(Scene):
+    def construct(self):
+        SCALE  = 1.1
+        PIVOT  = UP * 2.6
+        DT     = 0.02
+        L1, L2 = 1.5, 1.2
+
+        # Pre-simulate all trajectories up front
+        S1  = sim_simple(np.radians(40), 750, DT)
+        S3  = sim_double(np.radians(120), np.radians(120), 750, DT, L1, L2)
+        th0 = np.radians(120)
+        S4A = sim_double(th0,                    th0, 2000, DT, L1, L2)
+        S4B = sim_double(th0 + np.radians(0.5),  th0, 2000, DT, L1, L2)
+
+        pivot_dot = Dot(PIVOT, radius=0.07, color=WHITE)
+        self.add(pivot_dot)
+
+        # ── Scene 1: Predictable single pendulum ───────────────────────────────
+        x0, y0 = S1[0]
+        bob_s = Dot(PIVOT + np.array([x0, y0, 0])*SCALE, radius=0.16, color=BLUE_B)
+        rod_s = Line(PIVOT, bob_s.get_center(), color=GRAY_A, stroke_width=3)
+
+        f1 = ValueTracker(0)
+
+        def upd_bob_s(mob, dt):
+            f = min(int(f1.get_value()), len(S1)-1)
+            x, y = S1[f]
+            mob.move_to(PIVOT + np.array([x, y, 0])*SCALE)
+
+        def upd_rod_s(mob, dt):
+            mob.put_start_and_end_on(PIVOT, bob_s.get_center())
+
+        bob_s.add_updater(upd_bob_s)
+        rod_s.add_updater(upd_rod_s)
+
+        trace_s = TracedPath(
+            bob_s.get_center,
+            stroke_color=BLUE_B, stroke_width=1.8, dissipating_time=3,
+        )
+        label_pred = Text("Predecible", font_size=26, color=GRAY_A).to_edge(DOWN, buff=0.7)
+
+        self.play(Create(rod_s), GrowFromCenter(bob_s), run_time=0.5)
+        self.add(trace_s)
+        self.play(FadeIn(label_pred))
+        self.play(f1.animate.set_value(len(S1)-1), run_time=len(S1)*DT, rate_func=linear)
+
+        bob_s.remove_updater(upd_bob_s)
+        rod_s.remove_updater(upd_rod_s)
+
+        # ── Scene 2: Add a second arm ──────────────────────────────────────────
+        xe, ye = S1[-1]
+        p1e = PIVOT + np.array([xe, ye, 0])*SCALE
+        p2e = p1e + DOWN * L2 * SCALE
+
+        rod2_appear = Line(p1e, p2e, color=GRAY_B, stroke_width=3)
+        bob2_appear = Dot(p2e, radius=0.14, color=BLUE_B)
+        label_q = Text("?", font_size=40, color=YELLOW).move_to(label_pred)
+
+        self.play(FadeOut(trace_s), FadeOut(label_pred))
+        self.play(Create(rod2_appear), GrowFromCenter(bob2_appear), run_time=0.8)
+        self.play(FadeIn(label_q))
+        self.wait(0.6)
+
+        # ── Scene 3: Single double pendulum, chaotic trail ─────────────────────
+        self.play(
+            FadeOut(rod_s), FadeOut(bob_s),
+            FadeOut(rod2_appear), FadeOut(bob2_appear),
+            FadeOut(label_q),
+        )
+
+        x1_0, y1_0, x2_0, y2_0 = S3[0]
+        rod1_d = Line(PIVOT,
+                      PIVOT + np.array([x1_0, y1_0, 0])*SCALE,
+                      color=GRAY_A, stroke_width=3)
+        rod2_d = Line(PIVOT + np.array([x1_0, y1_0, 0])*SCALE,
+                      PIVOT + np.array([x2_0, y2_0, 0])*SCALE,
+                      color=GRAY_A, stroke_width=3)
+        bob1_d = Dot(PIVOT + np.array([x1_0, y1_0, 0])*SCALE, radius=0.13, color=BLUE_C)
+        bob2_d = Dot(PIVOT + np.array([x2_0, y2_0, 0])*SCALE, radius=0.16, color=YELLOW)
+        trace_d = TracedPath(
+            bob2_d.get_center,
+            stroke_color=YELLOW, stroke_width=2, dissipating_time=4,
+        )
+
+        f3 = ValueTracker(0)
+
+        def upd_dp(mob, dt):
+            f = min(int(f3.get_value()), len(S3)-1)
+            x1, y1, x2, y2 = S3[f]
+            p1 = PIVOT + np.array([x1, y1, 0])*SCALE
+            p2 = PIVOT + np.array([x2, y2, 0])*SCALE
+            rod1_d.put_start_and_end_on(PIVOT, p1)
+            rod2_d.put_start_and_end_on(p1, p2)
+            bob1_d.move_to(p1)
+            mob.move_to(p2)
+
+        bob2_d.add_updater(upd_dp)
+
+        self.play(
+            Create(rod1_d), Create(rod2_d),
+            GrowFromCenter(bob1_d), GrowFromCenter(bob2_d),
+            run_time=0.6,
+        )
+        self.add(trace_d)
+        self.play(f3.animate.set_value(len(S3)-1), run_time=len(S3)*DT, rate_func=linear)
+
+        bob2_d.remove_updater(upd_dp)
+
+        # ── Scene 4: Two pendulums, 0.5 degree apart ───────────────────────────
+        self.play(
+            FadeOut(rod1_d), FadeOut(rod2_d),
+            FadeOut(bob1_d), FadeOut(bob2_d),
+            FadeOut(trace_d),
+        )
+
+        def build_pend(pos, col):
+            x1, y1, x2, y2 = pos[0]
+            p1 = PIVOT + np.array([x1, y1, 0])*SCALE
+            p2 = PIVOT + np.array([x2, y2, 0])*SCALE
+            r1 = Line(PIVOT, p1, color=col, stroke_width=2.5)
+            r2 = Line(p1, p2, color=col, stroke_width=2.5)
+            b1 = Dot(p1, radius=0.12, color=col)
+            b2 = Dot(p2, radius=0.15, color=col)
+            tr = TracedPath(b2.get_center, stroke_color=col, stroke_width=1.8, dissipating_time=5)
+            return r1, r2, b1, b2, tr
+
+        rA1, rA2, bA1, bA2, trA = build_pend(S4A, BLUE)
+        rB1, rB2, bB1, bB2, trB = build_pend(S4B, RED)
+
+        delta_lbl = MathTex(r"\Delta\theta = 0.5^\circ", font_size=26, color=GRAY_A)\
+            .to_corner(UR, buff=0.5)
+
+        f4 = ValueTracker(0)
+
+        def make_upd(pos, r1, r2, b1):
+            def upd(mob, dt):
+                f = min(int(f4.get_value()), len(pos)-1)
+                x1, y1, x2, y2 = pos[f]
+                p1 = PIVOT + np.array([x1, y1, 0])*SCALE
+                p2 = PIVOT + np.array([x2, y2, 0])*SCALE
+                r1.put_start_and_end_on(PIVOT, p1)
+                r2.put_start_and_end_on(p1, p2)
+                b1.move_to(p1)
+                mob.move_to(p2)
+            return upd
+
+        bA2.add_updater(make_upd(S4A, rA1, rA2, bA1))
+        bB2.add_updater(make_upd(S4B, rB1, rB2, bB1))
+
+        self.play(
+            Create(rA1), Create(rA2), GrowFromCenter(bA1), GrowFromCenter(bA2),
+            Create(rB1), Create(rB2), GrowFromCenter(bB1), GrowFromCenter(bB2),
+            FadeIn(delta_lbl),
+            run_time=0.7,
+        )
+        self.add(trA, trB)
+        self.play(f4.animate.set_value(len(S4A)-1), run_time=len(S4A)*DT, rate_func=linear)
+
+        bA2.clear_updaters()
+        bB2.clear_updaters()
+
+        # ── Scene 5: End card ──────────────────────────────────────────────────
+        self.play(
+            FadeOut(rA1), FadeOut(rA2), FadeOut(bA1), FadeOut(bA2),
+            FadeOut(rB1), FadeOut(rB2), FadeOut(bB1), FadeOut(bB2),
+            FadeOut(delta_lbl), FadeOut(pivot_dot),
+        )
+
+        end_title = Text(
+            "Dependencia sensible\nde las condiciones iniciales",
+            font_size=30, color=WHITE, line_spacing=1.3,
+        )
+        end_sub = Text(
+            "El efecto mariposa",
+            font_size=22, color=GRAY_B,
+        ).next_to(end_title, DOWN, buff=0.4)
+
+        self.play(FadeIn(end_title, shift=UP*0.2))
+        self.play(FadeIn(end_sub, shift=UP*0.2))
+        self.wait(3)
+        self.play(
+            FadeOut(end_title), FadeOut(end_sub),
+            FadeOut(trA), FadeOut(trB),
+        )

--- a/experiments/manim-skills-comparison/manim-skill-yusuke/script.py
+++ b/experiments/manim-skills-comparison/manim-skill-yusuke/script.py
@@ -1,0 +1,629 @@
+from manim import *
+import numpy as np
+
+
+# ─── Physics helpers ──────────────────────────────────────────────────────────
+
+def pendulum_position(pivot, length, angle):
+    """Return the (x,y,0) position of a pendulum bob given pivot, length, angle from vertical."""
+    x = pivot[0] + length * np.sin(angle)
+    y = pivot[1] - length * np.cos(angle)
+    return np.array([x, y, 0])
+
+
+def double_pendulum_derivatives(state, L1=1.5, L2=1.5, m1=1.0, m2=1.0, g=9.8):
+    """Return dstate/dt for a double pendulum.
+    state = [theta1, omega1, theta2, omega2]
+    """
+    t1, w1, t2, w2 = state
+    dt = t2 - t1
+    denom1 = (m1 + m2) * L1 - m2 * L1 * np.cos(dt) ** 2
+    denom2 = (L2 / L1) * denom1
+
+    dt1 = w1
+    dt2 = w2
+
+    dw1 = (
+        m2 * L1 * w1 ** 2 * np.sin(dt) * np.cos(dt)
+        + m2 * g * np.sin(t2) * np.cos(dt)
+        + m2 * L2 * w2 ** 2 * np.sin(dt)
+        - (m1 + m2) * g * np.sin(t1)
+    ) / denom1
+
+    dw2 = (
+        -m2 * L2 * w2 ** 2 * np.sin(dt) * np.cos(dt)
+        + (m1 + m2) * g * np.sin(t1) * np.cos(dt)
+        - (m1 + m2) * L1 * w1 ** 2 * np.sin(dt)
+        - (m1 + m2) * g * np.sin(t2)
+    ) / denom2
+
+    return np.array([dt1, dw1, dt2, dw2])
+
+
+def rk4_step(state, dt, **kwargs):
+    """Single RK4 integration step."""
+    k1 = double_pendulum_derivatives(state, **kwargs)
+    k2 = double_pendulum_derivatives(state + 0.5 * dt * k1, **kwargs)
+    k3 = double_pendulum_derivatives(state + 0.5 * dt * k2, **kwargs)
+    k4 = double_pendulum_derivatives(state + dt * k3, **kwargs)
+    return state + (dt / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)
+
+
+def simulate_double_pendulum(state0, n_steps, dt=0.02, **kwargs):
+    """Pre-compute a trajectory. Returns array of shape (n_steps, 4)."""
+    traj = np.zeros((n_steps, 4))
+    traj[0] = state0
+    for i in range(1, n_steps):
+        traj[i] = rk4_step(traj[i - 1], dt, **kwargs)
+    return traj
+
+
+# ─── Scene 1: Single Pendulum ─────────────────────────────────────────────────
+
+class Scene1_SinglePendulum(Scene):
+    def construct(self):
+        self.camera.background_color = BLACK
+
+        ## Scene1_SinglePendulum.title
+        title = Text("El péndulo predecible", font_size=40, color=WHITE)
+        title.to_edge(UP, buff=0.4)
+        self.add_subcaption("Un péndulo simple es perfectamente predecible.", duration=3)
+        self.play(FadeIn(title), run_time=1.5)
+
+        ## Scene1_SinglePendulum.pendulum_setup
+        PIVOT = np.array([0.0, 1.8, 0.0])
+        L = 2.2
+        pivot_dot = Dot(point=PIVOT, radius=0.08, color=GREY_B)
+
+        # ValueTracker for angle
+        theta = ValueTracker(PI / 4)
+
+        def make_rod():
+            bob_pos = pendulum_position(PIVOT, L, theta.get_value())
+            return Line(PIVOT, bob_pos, color=GREY_B, stroke_width=4)
+
+        def make_bob():
+            bob_pos = pendulum_position(PIVOT, L, theta.get_value())
+            return Dot(point=bob_pos, radius=0.18, color=TEAL_C)
+
+        rod = always_redraw(make_rod)
+        bob = always_redraw(make_bob)
+
+        self.add(pivot_dot, rod, bob)
+        self.play(FadeIn(pivot_dot), FadeIn(rod), FadeIn(bob), run_time=0.8)
+
+        ## Scene1_SinglePendulum.swing
+        self.add_subcaption("Su movimiento se repite, una y otra vez, para siempre.", duration=4)
+
+        # Swing back and forth three times
+        for target_angle in [PI / 4, -PI / 4, PI / 4, -PI / 4, PI / 4]:
+            self.play(
+                theta.animate.set_value(target_angle),
+                run_time=1.2,
+                rate_func=there_and_back if target_angle == PI / 4 else smooth,
+            )
+
+        self.wait(0.5)
+
+        ## Scene1_SinglePendulum.label
+        periodic_label = Text("Periódico. Predecible.", font_size=28, color=TEAL_A)
+        periodic_label.next_to(title, DOWN, buff=0.3)
+        self.add_subcaption("Periódico. Predecible. Aburrido.", duration=2)
+        self.play(Write(periodic_label), run_time=1.2)
+        self.wait(1)
+
+        self.play(FadeOut(title), FadeOut(periodic_label), FadeOut(rod),
+                  FadeOut(bob), FadeOut(pivot_dot), run_time=1.0)
+
+
+# ─── Scene 2: Double Pendulum Intro ──────────────────────────────────────────
+
+class Scene2_DoublePendulumIntro(Scene):
+    def construct(self):
+        self.camera.background_color = BLACK
+
+        ## Scene2_DoublePendulumIntro.title
+        title = Text("Agreguemos un segundo péndulo", font_size=40, color=WHITE)
+        title.to_edge(UP, buff=0.4)
+        self.add_subcaption("Ahora añadimos un segundo péndulo debajo del primero.", duration=3)
+        self.play(FadeIn(title), run_time=1.0)
+
+        ## Scene2_DoublePendulumIntro.setup
+        PIVOT = np.array([0.0, 2.0, 0.0])
+        L1, L2 = 1.6, 1.6
+        # Start near vertical
+        theta1_val = PI / 6
+        theta2_val = PI / 4
+
+        pivot_dot = Dot(point=PIVOT, radius=0.08, color=GREY_B)
+
+        t1 = ValueTracker(theta1_val)
+        t2 = ValueTracker(theta2_val)
+
+        def joint_pos():
+            return pendulum_position(PIVOT, L1, t1.get_value())
+
+        def bob2_pos():
+            jp = joint_pos()
+            return pendulum_position(jp, L2, t2.get_value())
+
+        rod1 = always_redraw(lambda: Line(PIVOT, joint_pos(), color=GREY_B, stroke_width=4))
+        joint_dot = always_redraw(lambda: Dot(point=joint_pos(), radius=0.1, color=GREY_C))
+        rod2 = always_redraw(lambda: Line(joint_pos(), bob2_pos(), color=GREY_B, stroke_width=4))
+        bob2 = always_redraw(lambda: Dot(point=bob2_pos(), radius=0.18, color=GOLD))
+
+        # First show just the first pendulum
+        self.add(pivot_dot, rod1, joint_dot)
+        self.play(Create(rod1), FadeIn(joint_dot), FadeIn(pivot_dot), run_time=1.0)
+
+        # Then add second rod and bob
+        self.add_subcaption("Por un momento, todavía se ve ordenado.", duration=3)
+        self.play(Create(rod2), FadeIn(bob2), run_time=1.0)
+
+        # Labels
+        label1 = Text("varilla 1", font_size=22, color=GREY_A)
+        label2 = Text("varilla 2", font_size=22, color=GREY_A)
+
+        def update_label1(m):
+            jp = joint_pos()
+            midpoint = (PIVOT + jp) / 2
+            m.move_to(midpoint + LEFT * 0.5)
+
+        def update_label2(m):
+            jp = joint_pos()
+            bp = bob2_pos()
+            midpoint = (jp + bp) / 2
+            m.move_to(midpoint + LEFT * 0.5)
+
+        label1.add_updater(update_label1)
+        label2.add_updater(update_label2)
+        self.add(label1, label2)
+        self.play(FadeIn(label1), FadeIn(label2), run_time=0.6)
+        self.wait(0.5)
+
+        ## Scene2_DoublePendulumIntro.simulate_small
+        # Simulate a small motion using pre-computed trajectory
+        state0 = np.array([theta1_val, 0.0, theta2_val, 0.0])
+        n = 120
+        traj = simulate_double_pendulum(state0, n, dt=0.04)
+
+        self.add_subcaption("La complejidad crece con cada oscilación.", duration=3)
+
+        # Animate through pre-computed frames
+        for i in range(0, n, 4):
+            t1.set_value(traj[i, 0])
+            t2.set_value(traj[i, 2])
+            self.wait(0.04)
+
+        self.wait(0.5)
+        self.play(
+            FadeOut(title), FadeOut(rod1), FadeOut(rod2), FadeOut(bob2),
+            FadeOut(joint_dot), FadeOut(pivot_dot), FadeOut(label1), FadeOut(label2),
+            run_time=1.0
+        )
+
+
+# ─── Scene 3: Chaos Reveal ────────────────────────────────────────────────────
+
+class Scene3_ChaosReveal(Scene):
+    def construct(self):
+        self.camera.background_color = BLACK
+
+        ## Scene3_ChaosReveal.title
+        title = Text("Caos: mismas reglas, destino distinto", font_size=36, color=WHITE)
+        title.to_edge(UP, buff=0.3)
+        self.add_subcaption(
+            "Dos péndulos dobles, con condiciones iniciales casi idénticas.", duration=3
+        )
+        self.play(FadeIn(title), run_time=0.8)
+
+        PIVOT = np.array([0.0, 2.5, 0.0])
+        L1, L2 = 1.4, 1.4
+
+        # Two initial conditions that differ by epsilon
+        eps = 0.001
+        state_A = np.array([PI / 2.1, 0.0, PI / 2.0, 0.0])
+        state_B = state_A + np.array([eps, 0.0, 0.0, 0.0])
+
+        N = 500
+        dt = 0.02
+        traj_A = simulate_double_pendulum(state_A, N, dt=dt)
+        traj_B = simulate_double_pendulum(state_B, N, dt=dt)
+
+        # Value trackers for frame index
+        frame = ValueTracker(0)
+
+        def get_idx():
+            return int(frame.get_value())
+
+        def joint_A():
+            i = get_idx()
+            return pendulum_position(PIVOT, L1, traj_A[i, 0])
+
+        def bob2_A():
+            jp = joint_A()
+            return pendulum_position(jp, L2, traj_A[get_idx(), 2])
+
+        def joint_B():
+            i = get_idx()
+            return pendulum_position(PIVOT, L1, traj_B[i, 0])
+
+        def bob2_B():
+            jp = joint_B()
+            return pendulum_position(jp, L2, traj_B[get_idx(), 2])
+
+        # Pendulum A (TEAL)
+        pivot_dot = Dot(PIVOT, radius=0.08, color=GREY_B)
+        rod1_A = always_redraw(lambda: Line(PIVOT, joint_A(), color=TEAL_C, stroke_width=3))
+        joint_dot_A = always_redraw(lambda: Dot(joint_A(), radius=0.09, color=TEAL_C))
+        rod2_A = always_redraw(lambda: Line(joint_A(), bob2_A(), color=TEAL_C, stroke_width=3))
+        bob_A = always_redraw(lambda: Dot(bob2_A(), radius=0.16, color=TEAL_C,
+                                          fill_opacity=1).set_stroke(TEAL_A, width=2))
+
+        # Pendulum B (GOLD)
+        rod1_B = always_redraw(lambda: Line(PIVOT, joint_B(), color=GOLD, stroke_width=3))
+        joint_dot_B = always_redraw(lambda: Dot(joint_B(), radius=0.09, color=GOLD))
+        rod2_B = always_redraw(lambda: Line(joint_B(), bob2_B(), color=GOLD, stroke_width=3))
+        bob_B = always_redraw(lambda: Dot(bob2_B(), radius=0.16, color=GOLD,
+                                          fill_opacity=1).set_stroke(GOLD_A, width=2))
+
+        # Legends
+        legend_A = VGroup(
+            Dot(radius=0.12, color=TEAL_C),
+            Text("Péndulo A", font_size=22, color=TEAL_C)
+        ).arrange(RIGHT, buff=0.15).to_corner(DL, buff=0.5)
+        legend_B = VGroup(
+            Dot(radius=0.12, color=GOLD),
+            Text("Péndulo B", font_size=22, color=GOLD)
+        ).arrange(RIGHT, buff=0.15).next_to(legend_A, RIGHT, buff=0.6)
+
+        diff_label = Text("Δθ₁ = 0.001 rad", font_size=20, color=RED_B)
+        diff_label.to_corner(DR, buff=0.5)
+
+        self.add(
+            pivot_dot,
+            rod1_A, joint_dot_A, rod2_A, bob_A,
+            rod1_B, joint_dot_B, rod2_B, bob_B,
+            legend_A, legend_B, diff_label
+        )
+        self.play(
+            FadeIn(VGroup(rod1_A, joint_dot_A, rod2_A, bob_A,
+                          rod1_B, joint_dot_B, rod2_B, bob_B, pivot_dot)),
+            FadeIn(legend_A), FadeIn(legend_B), FadeIn(diff_label),
+            run_time=1.0
+        )
+
+        ## Scene3_ChaosReveal.phase1: they start together
+        self.add_subcaption("Al principio, se mueven juntos...", duration=3)
+        self.play(frame.animate.set_value(80), run_time=3.0, rate_func=linear)
+
+        ## Scene3_ChaosReveal.phase2 — they diverge
+        self.add_subcaption(
+            "Luego se separan: completamente, de forma impredecible.", duration=4
+        )
+        self.play(frame.animate.set_value(300), run_time=4.5, rate_func=linear)
+
+        ## Scene3_ChaosReveal.chaos_label
+        chaos_label = Text("Esto es CAOS", font_size=44, color=RED_B)
+        chaos_label.move_to(DOWN * 2.8)
+        self.add_subcaption(
+            "Esto es caos: determinismo sin predictibilidad.", duration=3
+        )
+        self.play(Write(chaos_label), run_time=1.2)
+        self.wait(1.5)
+
+        self.play(
+            FadeOut(VGroup(title, rod1_A, joint_dot_A, rod2_A, bob_A,
+                           rod1_B, joint_dot_B, rod2_B, bob_B, pivot_dot,
+                           legend_A, legend_B, diff_label, chaos_label)),
+            run_time=1.0
+        )
+
+
+# ─── Scene 4: Phase Portrait ──────────────────────────────────────────────────
+
+class Scene4_PhasePortrait(Scene):
+    def construct(self):
+        self.camera.background_color = BLACK
+
+        ## Scene4_PhasePortrait.title
+        title = Text("Espacio de fases: donde vive el caos", font_size=36, color=WHITE)
+        title.to_edge(UP, buff=0.3)
+        self.add_subcaption(
+            "En el espacio de fases, el movimiento ordenado traza elipses limpias.", duration=3
+        )
+        self.play(FadeIn(title), run_time=0.8)
+
+        # Build axes
+        axes = Axes(
+            x_range=[-PI, PI, PI / 2],
+            y_range=[-10, 10, 5],
+            x_length=9,
+            y_length=5.5,
+            axis_config={"color": GREY_B, "stroke_width": 2},
+            tips=False,
+        )
+        axes.move_to(ORIGIN + DOWN * 0.3)
+
+        x_label = Text("θ₂ (ángulo)", font_size=22, color=GREY_A).next_to(
+            axes.x_axis, DOWN, buff=0.25
+        )
+        y_label = Text("ω₂ (velocidad)", font_size=22, color=GREY_A).next_to(
+            axes.y_axis, LEFT, buff=0.15
+        )
+
+        self.play(Create(axes), Write(x_label), Write(y_label), run_time=1.5)
+
+        ## Scene4_PhasePortrait.simple_ellipse
+        # Show a simple pendulum's phase portrait first (ellipse)
+        ellipse_points = []
+        for t_val in np.linspace(0, 2 * PI, 200):
+            angle = 0.8 * np.cos(t_val)
+            vel = -0.8 * np.sin(t_val) * 3
+            pt = axes.c2p(angle, vel)
+            ellipse_points.append(pt)
+
+        ellipse = VMobject(color=TEAL_C, stroke_width=2.5)
+        ellipse.set_points_as_corners(ellipse_points)
+        ellipse.make_smooth()
+
+        simple_label = Text("Péndulo simple: elipse cerrada", font_size=20, color=TEAL_C)
+        simple_label.to_corner(UL, buff=0.4).shift(DOWN * 1.0)
+
+        self.add_subcaption("Un péndulo simple traza una elipse cerrada y ordenada.", duration=2.5)
+        self.play(Create(ellipse), FadeIn(simple_label), run_time=2.5)
+        self.wait(0.5)
+
+        ## Scene4_PhasePortrait.chaotic_trace
+        # Simulate chaotic double pendulum and trace theta2 vs omega2
+        state0 = np.array([PI / 2.1, 0.0, PI / 2.0, 0.0])
+        N = 2000
+        traj = simulate_double_pendulum(state0, N, dt=0.02)
+
+        # Wrap theta2 to [-pi, pi]
+        theta2_vals = traj[:, 2]
+        omega2_vals = traj[:, 3]
+        # Clip omega2 to axes range to avoid off-screen points
+        omega2_vals = np.clip(omega2_vals, -9.5, 9.5)
+
+        # Build phase path in chunks and draw it progressively
+        self.play(FadeOut(ellipse), FadeOut(simple_label), run_time=0.8)
+
+        chaos_label = Text("Péndulo doble: nunca se repite", font_size=20, color=GOLD)
+        chaos_label.to_corner(UL, buff=0.4).shift(DOWN * 1.0)
+        self.add_subcaption(
+            "Pero el péndulo doble nunca se repite: vaga para siempre.", duration=4
+        )
+        self.play(FadeIn(chaos_label), run_time=0.4)
+
+        # Draw the phase portrait progressively as colored dots
+        chunk_size = 100
+        n_chunks = N // chunk_size
+        colors = color_gradient([BLUE_B, PURPLE_B, RED_B], n_chunks)
+
+        for c_idx in range(n_chunks):
+            start = c_idx * chunk_size
+            end = start + chunk_size
+            pts = [
+                axes.c2p(
+                    np.clip((theta2_vals[k] + PI) % (2 * PI) - PI, -PI + 0.1, PI - 0.1),
+                    omega2_vals[k]
+                )
+                for k in range(start, end)
+            ]
+            path = VMobject(
+                color=colors[c_idx],
+                stroke_width=1.2,
+                stroke_opacity=0.8
+            )
+            path.set_points_as_corners(pts)
+            self.add(path)
+            self.wait(0.04)
+
+        self.wait(1.0)
+
+        self.play(
+            FadeOut(VGroup(title, axes, x_label, y_label, chaos_label)),
+            run_time=1.0,
+        )
+
+
+# ─── Scene 5: Lyapunov Exponent ───────────────────────────────────────────────
+
+class Scene5_LyapunovExponent(Scene):
+    def construct(self):
+        self.camera.background_color = BLACK
+
+        ## Scene5_LyapunovExponent.title
+        title = Text("Midiendo el caos: el exponente de Lyapunov", font_size=34, color=WHITE)
+        title.to_edge(UP, buff=0.3)
+        self.add_subcaption(
+            "La distancia entre trayectorias crece exponencialmente.", duration=3
+        )
+        self.play(FadeIn(title), run_time=0.8)
+
+        ## Scene5_LyapunovExponent.divergence_plot
+        # Simulate two trajectories and compute separation
+        eps = 0.001
+        state_A = np.array([PI / 2.1, 0.0, PI / 2.0, 0.0])
+        state_B = state_A + np.array([eps, 0.0, 0.0, 0.0])
+        N = 300
+        dt = 0.02
+        traj_A = simulate_double_pendulum(state_A, N, dt=dt)
+        traj_B = simulate_double_pendulum(state_B, N, dt=dt)
+
+        # Compute angular separation (simple distance in state space)
+        sep = np.sqrt(
+            (traj_A[:, 0] - traj_B[:, 0]) ** 2 + (traj_A[:, 2] - traj_B[:, 2]) ** 2
+        )
+        sep = np.clip(sep, 1e-12, None)
+        log_sep = np.log(sep / eps)  # log of normalized separation
+
+        # Axes for the divergence plot
+        axes = Axes(
+            x_range=[0, N * dt, 1.0],
+            y_range=[-1, 8, 2],
+            x_length=8.5,
+            y_length=4.0,
+            axis_config={"color": GREY_B, "stroke_width": 2},
+            tips=False,
+        )
+        axes.shift(DOWN * 0.5)
+        x_label = Text("tiempo (s)", font_size=20, color=GREY_A).next_to(
+            axes.x_axis, DOWN, buff=0.2
+        )
+        y_label = Text("ln(separación)", font_size=20, color=GREY_A).next_to(
+            axes.y_axis, LEFT, buff=0.15
+        )
+
+        self.play(Create(axes), Write(x_label), Write(y_label), run_time=1.2)
+
+        # Build separation curve
+        time_vals = np.arange(N) * dt
+        log_sep_clipped = np.clip(log_sep, -1, 7.5)
+
+        sep_curve = axes.plot_parametric_curve(
+            lambda t: np.array([
+                t,
+                float(np.interp(t, time_vals, log_sep_clipped)),
+                0
+            ]),
+            t_range=[0, (N - 1) * dt, dt * 2],
+            color=GOLD,
+            stroke_width=3,
+        )
+
+        # Fitted exponential reference line
+        lambda_fit = 2.5  # approximate Lyapunov exponent
+        ref_line = axes.plot(
+            lambda t: lambda_fit * t,
+            x_range=[0, 2.5],
+            color=RED_B,
+            stroke_width=2,
+        )
+
+        self.add_subcaption(
+            "El exponente de Lyapunov λ > 0 es la firma del caos.", duration=4
+        )
+        self.play(Create(sep_curve), run_time=3.0, rate_func=linear)
+        self.play(Create(ref_line), run_time=1.0)
+
+        # Lambda annotation
+        lambda_eq = MathTex(r"\lambda > 0", font_size=44, color=RED_B)
+        lambda_eq.to_corner(UR, buff=0.8).shift(DOWN * 1.5)
+        self.play(Write(lambda_eq), run_time=0.8)
+
+        forecast_text = Text(
+            "Por qué los pronósticos fallan más allá de ~1 semana", font_size=22, color=GREY_A
+        )
+        forecast_text.next_to(lambda_eq, DOWN, buff=0.3)
+        self.add_subcaption(
+            "Esto explica por qué la predicción meteorológica a largo plazo es fundamentalmente imposible.",
+            duration=3
+        )
+        self.play(FadeIn(forecast_text), run_time=0.8)
+        self.wait(1.5)
+
+        self.play(
+            FadeOut(VGroup(title, axes, x_label, y_label, sep_curve,
+                           ref_line, lambda_eq, forecast_text)),
+            run_time=1.0
+        )
+
+
+# ─── Scene 6: Conclusion ──────────────────────────────────────────────────────
+
+class Scene6_Conclusion(Scene):
+    def construct(self):
+        self.camera.background_color = BLACK
+
+        ## Scene6_Conclusion.split_screen
+        # Left: simple pendulum trace (ellipse)
+        # Right: chaotic trace
+
+        left_axes = Axes(
+            x_range=[-PI / 2, PI / 2, PI / 4],
+            y_range=[-4, 4, 2],
+            x_length=4.0,
+            y_length=3.5,
+            axis_config={"color": GREY_C, "stroke_width": 1.5},
+            tips=False,
+        ).shift(LEFT * 3.2 + DOWN * 0.5)
+
+        right_axes = Axes(
+            x_range=[-PI, PI, PI / 2],
+            y_range=[-10, 10, 5],
+            x_length=4.0,
+            y_length=3.5,
+            axis_config={"color": GREY_C, "stroke_width": 1.5},
+            tips=False,
+        ).shift(RIGHT * 3.2 + DOWN * 0.5)
+
+        # Divider line
+        divider = DashedLine(UP * 3.5, DOWN * 3.5, color=GREY_D, stroke_width=1.5)
+
+        self.add_subcaption("Las leyes son exactas. El futuro está determinado.", duration=3)
+        self.play(
+            Create(left_axes), Create(right_axes),
+            Create(divider), run_time=1.2
+        )
+
+        # Left ellipse (simple pendulum)
+        simple_pts = []
+        for t_val in np.linspace(0, 2 * PI, 300):
+            angle = 0.6 * np.cos(t_val)
+            vel = -0.6 * np.sin(t_val) * 3.5
+            simple_pts.append(left_axes.c2p(angle, vel))
+        simple_ellipse = VMobject(color=TEAL_C, stroke_width=2.5)
+        simple_ellipse.set_points_as_corners(simple_pts)
+        simple_ellipse.make_smooth()
+
+        # Right chaotic trace (pre-computed)
+        state0 = np.array([PI / 2.1, 0.0, PI / 2.0, 0.0])
+        traj = simulate_double_pendulum(state0, 1500, dt=0.022)
+        theta2_vals = np.clip(
+            (traj[:, 2] + PI) % (2 * PI) - PI, -PI + 0.1, PI - 0.1
+        )
+        omega2_vals = np.clip(traj[:, 3], -9.5, 9.5)
+
+        chaotic_pts = [right_axes.c2p(theta2_vals[k], omega2_vals[k])
+                       for k in range(0, 1500, 3)]
+        chaotic_path = VMobject(color=GOLD, stroke_width=1.0, stroke_opacity=0.7)
+        chaotic_path.set_points_as_corners(chaotic_pts)
+
+        # Labels above each panel
+        label_simple = Text("Péndulo simple", font_size=22, color=TEAL_C)
+        label_simple.next_to(left_axes, UP, buff=0.3)
+        label_chaotic = Text("Péndulo doble", font_size=22, color=GOLD)
+        label_chaotic.next_to(right_axes, UP, buff=0.3)
+
+        self.play(
+            Create(simple_ellipse),
+            Create(chaotic_path),
+            FadeIn(label_simple),
+            FadeIn(label_chaotic),
+            run_time=2.5,
+        )
+        self.wait(0.5)
+
+        ## Scene6_Conclusion.final_text
+        self.add_subcaption(
+            "¿Pero la predicción? Imposible más allá de un instante.", duration=3
+        )
+        self.wait(2)
+
+        final_text = Text(
+            "Determinismo  ≠  Predictibilidad",
+            font_size=42,
+            color=WHITE,
+        )
+        final_text.set_color_by_gradient(TEAL_C, WHITE, GOLD)
+        final_text.to_edge(DOWN, buff=0.6)
+
+        self.add_subcaption(
+            "Determinismo no significa predictibilidad.", duration=3
+        )
+        self.play(Write(final_text), run_time=2.0)
+        self.wait(2.5)
+
+        self.play(FadeOut(Group(*self.mobjects)), run_time=1.5)

--- a/experiments/manim-skills-comparison/manim-video-affaan/script.py
+++ b/experiments/manim-skills-comparison/manim-video-affaan/script.py
@@ -1,0 +1,207 @@
+from manim import *
+import numpy as np
+
+
+# ── Physics ────────────────────────────────────────────────────────────────────
+
+def _rk4(f, y, t, dt, *args):
+    k1 = np.array(f(y, t, *args))
+    k2 = np.array(f(y + dt/2*k1, t+dt/2, *args))
+    k3 = np.array(f(y + dt/2*k2, t+dt/2, *args))
+    k4 = np.array(f(y + dt*k3, t+dt, *args))
+    return y + dt/6*(k1 + 2*k2 + 2*k3 + k4)
+
+def _ode(y, t, L1, L2, g=9.8):
+    th1, w1, th2, w2 = y
+    d = th2 - th1
+    D1 = (2*L1 - L1*np.cos(d)**2)
+    D2 = L2/L1*D1
+    dw1 = (L1*w1**2*np.sin(d)*np.cos(d) + g*np.sin(th2)*np.cos(d)
+           + L2*w2**2*np.sin(d) - 2*g*np.sin(th1)) / D1
+    dw2 = (-L2*w2**2*np.sin(d)*np.cos(d) + 2*g*np.sin(th1)*np.cos(d)
+           - 2*L1*w1**2*np.sin(d) - 2*g*np.sin(th2)) / D2
+    return [w1, dw1, w2, dw2]
+
+def sim(th1, th2, steps, dt=0.02, L1=1.5, L2=1.2):
+    y = np.array([th1, 0.0, th2, 0.0])
+    out = []
+    for i in range(steps):
+        x1 = L1*np.sin(y[0]); y1 = -L1*np.cos(y[0])
+        x2 = x1+L2*np.sin(y[2]); y2 = y1-L2*np.cos(y[2])
+        out.append((x1, y1, x2, y2))
+        y = _rk4(_ode, y, i*dt, dt, L1, L2)
+    return out
+
+
+PIVOT = UP * 2.8
+SC    = 1.0          # world → Manim scale
+DT    = 0.02
+TH0   = np.radians(120)
+
+BLUE_PEND = "#4B9CD3"
+RED_PEND  = "#E8474C"
+
+
+def make_pend(pos, color):
+    """Build rod1, rod2, bob1, bob2 at frame 0."""
+    x1, y1, x2, y2 = pos[0]
+    p1 = PIVOT + np.array([x1, y1, 0])*SC
+    p2 = PIVOT + np.array([x2, y2, 0])*SC
+    r1 = Line(PIVOT, p1, color=color, stroke_width=2.5, stroke_opacity=0.9)
+    r2 = Line(p1, p2, color=color, stroke_width=2.5, stroke_opacity=0.9)
+    b1 = Dot(p1, radius=0.11, color=color, fill_opacity=0.85)
+    b2 = Dot(p2, radius=0.15, color=color)
+    return r1, r2, b1, b2
+
+
+def attach_updater(b2, pos, tracker, r1, r2, b1):
+    def upd(mob, dt):
+        i = min(int(tracker.get_value()), len(pos)-1)
+        x1, y1, x2, y2 = pos[i]
+        p1 = PIVOT + np.array([x1, y1, 0])*SC
+        p2 = PIVOT + np.array([x2, y2, 0])*SC
+        r1.put_start_and_end_on(PIVOT, p1)
+        r2.put_start_and_end_on(p1, p2)
+        b1.move_to(p1)
+        mob.move_to(p2)
+    b2.add_updater(upd)
+    return upd
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scene 1 — Prove: they start identical
+# Show both pendulums superimposed at the exact same position, then label the
+# 0.5° gap so the viewer can see how small the difference actually is.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class Scene1_SameStart(Scene):
+    def construct(self):
+        posA = sim(TH0, TH0, 1, DT)
+        posB = sim(TH0 + np.radians(0.5), TH0, 1, DT)
+
+        pivot = Dot(PIVOT, radius=0.07, color=WHITE)
+
+        rA1, rA2, bA1, bA2 = make_pend(posA, BLUE_PEND)
+        rB1, rB2, bB1, bB2 = make_pend(posB, RED_PEND)
+
+        # Angle arc showing the 0.5° gap between the two first arms
+        start_angle = np.radians(90) - TH0                # 90° - 120° = -30° (from East)
+        delta_angle = np.radians(0.5)
+        arc = Arc(
+            radius=0.9,
+            start_angle=start_angle,
+            angle=delta_angle,
+            color=YELLOW,
+            stroke_width=3,
+        ).shift(PIVOT)
+
+        label_delta = MathTex(r"0.5^\circ", font_size=22, color=YELLOW)\
+            .next_to(arc, LEFT, buff=0.1)
+
+        thesis = Text(
+            "Mismo inicio: 0.5° de diferencia",
+            font_size=24, color=WHITE,
+        ).to_edge(DOWN, buff=0.6)
+
+        self.add(pivot)
+        self.play(Create(rA1), Create(rA2), GrowFromCenter(bA1), GrowFromCenter(bA2), run_time=0.6)
+        self.play(Create(rB1), Create(rB2), GrowFromCenter(bB1), GrowFromCenter(bB2), run_time=0.4)
+        self.play(Create(arc), FadeIn(label_delta), FadeIn(thesis))
+        self.wait(2)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scene 2 — Prove: they diverge
+# Run both pendulums together. The first ~10s they track closely; then they
+# explode apart. A vertical "sync" indicator fades out as they separate.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class Scene2_Divergence(Scene):
+    def construct(self):
+        N = 2000
+        posA = sim(TH0, TH0, N, DT)
+        posB = sim(TH0 + np.radians(0.5), TH0, N, DT)
+
+        pivot = Dot(PIVOT, radius=0.07, color=WHITE)
+        rA1, rA2, bA1, bA2 = make_pend(posA, BLUE_PEND)
+        rB1, rB2, bB1, bB2 = make_pend(posB, RED_PEND)
+        trA = TracedPath(bA2.get_center, stroke_color=BLUE_PEND, stroke_width=1.5, dissipating_time=4)
+        trB = TracedPath(bB2.get_center, stroke_color=RED_PEND,  stroke_width=1.5, dissipating_time=4)
+
+        # Sync label (fades as they diverge — driven by angular distance)
+        sync_label = Text("en sincronía", font_size=20, color=GREEN_B).to_edge(DOWN, buff=0.6)
+
+        f = ValueTracker(0)
+        attach_updater(bA2, posA, f, rA1, rA2, bA1)
+        attach_updater(bB2, posB, f, rB1, rB2, bB1)
+
+        # Compute frame index where angular distance first exceeds 45°
+        diverge_frame = N - 1
+        for i, (a, _, _, _) in enumerate(posA):
+            diff = abs(posA[i][0] - posB[i][0])   # x1 difference as proxy
+            if diff > 0.8:
+                diverge_frame = i
+                break
+
+        self.add(pivot)
+        self.play(
+            Create(rA1), Create(rA2), GrowFromCenter(bA1), GrowFromCenter(bA2),
+            Create(rB1), Create(rB2), GrowFromCenter(bB1), GrowFromCenter(bB2),
+            FadeIn(sync_label),
+            run_time=0.6,
+        )
+        self.add(trA, trB)
+
+        # Phase 1: run to divergence frame
+        t_diverge = diverge_frame * DT
+        self.play(f.animate.set_value(diverge_frame), run_time=t_diverge, rate_func=linear)
+        self.play(FadeOut(sync_label), run_time=0.5)
+
+        # Phase 2: run the rest
+        self.play(f.animate.set_value(N-1), run_time=(N-1-diverge_frame)*DT, rate_func=linear)
+
+        bA2.clear_updaters()
+        bB2.clear_updaters()
+        self.wait(0.5)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scene 3 — Prove: different outcomes, same physics
+# Show the two full baked trails side-by-side with a minimal annotation.
+# No rods, no motion — just the evidence.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class Scene3_Outcomes(Scene):
+    def construct(self):
+        N = 2000
+        posA = sim(TH0, TH0, N, DT)
+        posB = sim(TH0 + np.radians(0.5), TH0, N, DT)
+
+        def bake(pos, color):
+            pts = [PIVOT + np.array([x2, y2, 0])*SC for _, _, x2, y2 in pos]
+            m = VMobject(stroke_color=color, stroke_width=1.2, stroke_opacity=0.8)
+            m.set_points_as_corners(pts)
+            return m
+
+        trailA = bake(posA, BLUE_PEND)
+        trailB = bake(posB, RED_PEND)
+
+        title = Text(
+            "Misma física.\nResultados distintos.",
+            font_size=28, color=WHITE, line_spacing=1.4,
+        )
+        sub = Text(
+            "Determinismo no significa predictibilidad.",
+            font_size=18, color=GRAY_B,
+        ).next_to(title, DOWN, buff=0.35)
+
+        legend_a = Dot(color=BLUE_PEND, radius=0.09).to_edge(DOWN, buff=1.1).shift(LEFT*1.2)
+        legend_b = Dot(color=RED_PEND,  radius=0.09).next_to(legend_a, RIGHT, buff=0.8)
+        label_a  = Text("θ₁ = 120.0°", font_size=16, color=BLUE_PEND).next_to(legend_a, RIGHT, buff=0.12)
+        label_b  = Text("θ₁ = 120.5°", font_size=16, color=RED_PEND).next_to(legend_b, RIGHT, buff=0.12)
+
+        self.play(Create(trailA), Create(trailB), run_time=1.5)
+        self.play(FadeIn(title, shift=UP*0.2))
+        self.play(FadeIn(sub), FadeIn(legend_a), FadeIn(legend_b), FadeIn(label_a), FadeIn(label_b))
+        self.wait(3.5)
+        self.play(*[FadeOut(m) for m in self.mobjects])

--- a/experiments/manim-skills-comparison/sin-skill/double_pendulum.py
+++ b/experiments/manim-skills-comparison/sin-skill/double_pendulum.py
@@ -1,0 +1,166 @@
+from manim import *
+import numpy as np
+
+
+def double_pendulum_ode(state, t, L1, L2, m1, m2, g):
+    th1, w1, th2, w2 = state
+    d = th2 - th1
+
+    den1 = (m1 + m2) * L1 - m2 * L1 * np.cos(d) ** 2
+    den2 = (L2 / L1) * den1
+
+    dth1 = w1
+    dw1 = (
+        m2 * L1 * w1**2 * np.sin(d) * np.cos(d)
+        + m2 * g * np.sin(th2) * np.cos(d)
+        + m2 * L2 * w2**2 * np.sin(d)
+        - (m1 + m2) * g * np.sin(th1)
+    ) / den1
+
+    dth2 = w2
+    dw2 = (
+        -m2 * L2 * w2**2 * np.sin(d) * np.cos(d)
+        + (m1 + m2) * g * np.sin(th1) * np.cos(d)
+        - (m1 + m2) * L1 * w1**2 * np.sin(d)
+        - (m1 + m2) * g * np.sin(th2)
+    ) / den2
+
+    return dth1, dw1, dth2, dw2
+
+
+def rk4_step(f, state, t, dt, *args):
+    k1 = np.array(f(state, t, *args))
+    k2 = np.array(f(state + dt / 2 * k1, t + dt / 2, *args))
+    k3 = np.array(f(state + dt / 2 * k2, t + dt / 2, *args))
+    k4 = np.array(f(state + dt * k3, t + dt, *args))
+    return state + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+
+
+def simulate(th1_0, th2_0, n_steps, dt, L1=1.5, L2=1.2, m1=1.0, m2=1.0, g=9.8):
+    state = np.array([th1_0, 0.0, th2_0, 0.0])
+    positions = []
+    for i in range(n_steps):
+        x1 = L1 * np.sin(state[0])
+        y1 = -L1 * np.cos(state[0])
+        x2 = x1 + L2 * np.sin(state[2])
+        y2 = y1 - L2 * np.cos(state[2])
+        positions.append((x1, y1, x2, y2))
+        state = rk4_step(double_pendulum_ode, state, i * dt, dt, L1, L2, m1, m2, g)
+    return positions
+
+
+class DoublePendulumChaos(Scene):
+    def construct(self):
+        # --- parameters ---
+        L1, L2 = 1.5, 1.2
+        SCALE = 1.4          # world-units to Manim units
+        PIVOT = UP * 2.8
+        DT = 0.016
+        N_STEPS = 520        # ~8 s at 60 fps equivalent
+        TRAIL_LEN = 120
+
+        # Two pendulums with a tiny angle difference (chaos demo)
+        CONFIGS = [
+            {"th1": np.radians(120), "th2": np.radians(120), "color": BLUE},
+            {"th1": np.radians(120.5), "th2": np.radians(120), "color": RED},
+        ]
+
+        # Pre-simulate
+        all_pos = []
+        for cfg in CONFIGS:
+            all_pos.append(simulate(cfg["th1"], cfg["th2"], N_STEPS, DT, L1, L2))
+
+        # --- title ---
+        title = Text("Péndulo doble", font_size=36, color=WHITE).to_edge(UP)
+        subtitle = Text(
+            "Delta theta = 0.5° de diferencia",
+            font_size=22,
+            color=GRAY_B,
+        ).next_to(title, DOWN, buff=0.15)
+        self.play(FadeIn(title, shift=DOWN * 0.3), FadeIn(subtitle, shift=DOWN * 0.3))
+        self.wait(0.4)
+
+        # --- static pivot dot ---
+        pivot_dot = Dot(PIVOT, radius=0.08, color=WHITE)
+        self.add(pivot_dot)
+
+        # Build Manim objects per pendulum
+        rods = []
+        bobs = []
+        trails = []
+        trail_points = [[] for _ in CONFIGS]
+
+        for i, cfg in enumerate(CONFIGS):
+            x1, y1, x2, y2 = all_pos[i][0]
+            p1 = PIVOT + np.array([x1, y1, 0]) * SCALE
+            p2 = PIVOT + np.array([x2, y2, 0]) * SCALE
+
+            rod1 = Line(PIVOT, p1, color=GRAY_A, stroke_width=2.5)
+            rod2 = Line(p1, p2, color=GRAY_A, stroke_width=2.5)
+            bob1 = Dot(p1, radius=0.12, color=cfg["color"]).set_opacity(0.8)
+            bob2 = Dot(p2, radius=0.16, color=cfg["color"])
+            trail = VMobject(stroke_width=1.5, stroke_color=cfg["color"])
+            trail.set_points_as_corners([p2, p2])
+
+            rods.append((rod1, rod2))
+            bobs.append((bob1, bob2))
+            trails.append(trail)
+            trail_points[i].append(p2.copy())
+
+            self.add(rod1, rod2, bob1, bob2, trail)
+
+        # --- animate ---
+        def update_pendulum(pend_idx, frame):
+            x1, y1, x2, y2 = all_pos[pend_idx][frame]
+            p1 = PIVOT + np.array([x1, y1, 0]) * SCALE
+            p2 = PIVOT + np.array([x2, y2, 0]) * SCALE
+
+            rod1, rod2 = rods[pend_idx]
+            bob1, bob2 = bobs[pend_idx]
+            trail = trails[pend_idx]
+
+            rod1.put_start_and_end_on(PIVOT, p1)
+            rod2.put_start_and_end_on(p1, p2)
+            bob1.move_to(p1)
+            bob2.move_to(p2)
+
+            trail_points[pend_idx].append(p2.copy())
+            if len(trail_points[pend_idx]) > TRAIL_LEN:
+                trail_points[pend_idx].pop(0)
+
+            pts = trail_points[pend_idx]
+            if len(pts) >= 2:
+                trail.set_points_as_corners(pts)
+
+        frame = ValueTracker(0)
+
+        def make_updater(idx):
+            def updater(mob, dt):
+                f = int(frame.get_value())
+                if f < N_STEPS:
+                    update_pendulum(idx, f)
+            return updater
+
+        for idx in range(len(CONFIGS)):
+            # attach updater to the bob (dummy target just to hook into the scene)
+            bobs[idx][1].add_updater(make_updater(idx))
+
+        self.play(
+            frame.animate.set_value(N_STEPS - 1),
+            run_time=N_STEPS * DT,
+            rate_func=linear,
+        )
+
+        for idx in range(len(CONFIGS)):
+            bobs[idx][1].remove_updater(make_updater(idx))
+
+        # --- end card ---
+        end_text = Text(
+            "Mismas condiciones iniciales,\ntrayectorias completamente distintas.",
+            font_size=24,
+            color=WHITE,
+            line_spacing=1.3,
+        ).to_edge(DOWN, buff=0.5)
+        self.play(FadeIn(end_text, shift=UP * 0.2))
+        self.wait(2.5)
+        self.play(FadeOut(end_text))


### PR DESCRIPTION
## Summary
- Adds `experiments/manim-skills-comparison/`: the four Manim scene scripts used to compare Claude Code skills (none, manim-composer, yusuke710/manim-skill, affaan-m/everything-claude-code manim-video) by rendering the same double pendulum chaos demo.
- All on-screen text (titles, labels, subcaptions) is in Spanish.
- Source comparison: https://www.reddit.com/r/manim/comments/1udub56/best_manim_skills_comparison_with_code_video/

## Test plan
- [ ] `manim -pql experiments/manim-skills-comparison/sin-skill/double_pendulum.py DoublePendulumChaos`
- [ ] `manim -pql experiments/manim-skills-comparison/manim-composer/double_pendulum_v2.py DoublePendulumNarrative`
- [ ] `manim -pql experiments/manim-skills-comparison/manim-skill-yusuke/script.py Scene1_SinglePendulum`
- [ ] `manim -pql experiments/manim-skills-comparison/manim-video-affaan/script.py Scene1_SameStart`