### PR TITLE
Fix: translate all on-screen text to English

### DIFF
--- a/experiments/manim-skills-comparison/README.md
+++ b/experiments/manim-skills-comparison/README.md
@@ -1,23 +1,21 @@
-# Comparación de skills de Manim para Claude Code
+# Manim Skills Comparison
 
-Cuatro skills de Claude Code para generar animaciones con Manim, puestas a prueba con el mismo encargo: un video sobre el péndulo doble como ejemplo de teoría del caos.
+Four Claude Code skills for generating Manim animations, each given the same prompt: a double pendulum chaos theory video.
 
-Origen de esta comparación: [r/manim - Best Manim skills comparison (with code + video)](https://www.reddit.com/r/manim/comments/1udub56/best_manim_skills_comparison_with_code_video/)
+Source: [r/manim - Best Manim skills comparison (with code + video)](https://www.reddit.com/r/manim/comments/1udub56/best_manim_skills_comparison_with_code_video/)
 
-## Skills comparados
+## Skills tested
 
-| Carpeta | Skill | Enfoque |
+| Folder | Skill | Approach |
 |---|---|---|
-| `sin-skill/` | Ninguno (Manim base) | Una sola clase, patrón manual de `ValueTracker` + `updater`. |
-| `manim-composer/` | `manim-composer` | Planifica un arco narrativo (`scenes.md`) antes de escribir código. |
-| `manim-skill-yusuke/` | [yusuke710/manim-skill](https://github.com/yusuke710/manim-skill) | Una clase por escena, subtítulos nativos vía `add_subcaption()`, stitching con ffmpeg. |
-| `manim-video-affaan/` | [affaan-m/everything-claude-code (manim-video)](https://github.com/affaan-m/everything-claude-code) | Cada escena debe demostrar una sola idea (tesis visual). |
+| `sin-skill/` | None (base Manim) | Single class, manual `ValueTracker` + `updater` pattern. |
+| `manim-composer/` | `manim-composer` | Plans a narrative arc (`scenes.md`) before writing any code. |
+| `manim-skill-yusuke/` | [yusuke710/manim-skill](https://github.com/yusuke710/manim-skill) | One class per scene, native `.srt` subtitles via `add_subcaption()`, ffmpeg stitch. |
+| `manim-video-affaan/` | [affaan-m/everything-claude-code (manim-video)](https://github.com/affaan-m/everything-claude-code) | Each scene must prove exactly one claim (visual thesis). |
 
-Todos los scripts simulan el péndulo doble con el mismo integrador RK4 y los mismos parámetros físicos, para que la única variable real sea el flujo de trabajo de cada skill.
+All scripts simulate the double pendulum with the same RK4 integrator and the same physical parameters — the only variable is each skill's workflow.
 
-Los videos resultantes y el análisis comparativo completo no se incluyen en este repositorio; este folder solo contiene el código fuente de las escenas (`Scene` classes de Manim) de cada skill.
-
-## Requisitos
+## Requirements
 
 ```bash
 pip install manim numpy
@@ -28,6 +26,6 @@ pip install manim numpy
 ```bash
 manim -pql sin-skill/double_pendulum.py DoublePendulumChaos
 manim -pql manim-composer/double_pendulum_v2.py DoublePendulumNarrative
-manim -pql manim-skill-yusuke/script.py Scene1_SinglePendulum  # y las demás Scene1-6
-manim -pql manim-video-affaan/script.py Scene1_SameStart        # y las demás Scene1-3
+manim -pql manim-skill-yusuke/script.py Scene1_SinglePendulum  # and Scene2..Scene6
+manim -pql manim-video-affaan/script.py Scene1_SameStart        # and Scene2..Scene3
 ```

--- a/experiments/manim-skills-comparison/manim-composer/double_pendulum_v2.py
+++ b/experiments/manim-skills-comparison/manim-composer/double_pendulum_v2.py
@@ -89,7 +89,7 @@ class DoublePendulumNarrative(Scene):
             bob_s.get_center,
             stroke_color=BLUE_B, stroke_width=1.8, dissipating_time=3,
         )
-        label_pred = Text("Predecible", font_size=26, color=GRAY_A).to_edge(DOWN, buff=0.7)
+        label_pred = Text("Predictable", font_size=26, color=GRAY_A).to_edge(DOWN, buff=0.7)
 
         self.play(Create(rod_s), GrowFromCenter(bob_s), run_time=0.5)
         self.add(trace_s)
@@ -219,11 +219,11 @@ class DoublePendulumNarrative(Scene):
         )
 
         end_title = Text(
-            "Dependencia sensible\nde las condiciones iniciales",
+            "Sensitive dependence\non initial conditions",
             font_size=30, color=WHITE, line_spacing=1.3,
         )
         end_sub = Text(
-            "El efecto mariposa",
+            "The Butterfly Effect",
             font_size=22, color=GRAY_B,
         ).next_to(end_title, DOWN, buff=0.4)
 

--- a/experiments/manim-skills-comparison/manim-skill-yusuke/script.py
+++ b/experiments/manim-skills-comparison/manim-skill-yusuke/script.py
@@ -65,9 +65,9 @@ class Scene1_SinglePendulum(Scene):
         self.camera.background_color = BLACK
 
         ## Scene1_SinglePendulum.title
-        title = Text("El péndulo predecible", font_size=40, color=WHITE)
+        title = Text("The Predictable Pendulum", font_size=40, color=WHITE)
         title.to_edge(UP, buff=0.4)
-        self.add_subcaption("Un péndulo simple es perfectamente predecible.", duration=3)
+        self.add_subcaption("A single pendulum is perfectly predictable.", duration=3)
         self.play(FadeIn(title), run_time=1.5)
 
         ## Scene1_SinglePendulum.pendulum_setup
@@ -93,7 +93,7 @@ class Scene1_SinglePendulum(Scene):
         self.play(FadeIn(pivot_dot), FadeIn(rod), FadeIn(bob), run_time=0.8)
 
         ## Scene1_SinglePendulum.swing
-        self.add_subcaption("Su movimiento se repite, una y otra vez, para siempre.", duration=4)
+        self.add_subcaption("Its motion repeats, tick by tick, forever.", duration=4)
 
         # Swing back and forth three times
         for target_angle in [PI / 4, -PI / 4, PI / 4, -PI / 4, PI / 4]:
@@ -106,9 +106,9 @@ class Scene1_SinglePendulum(Scene):
         self.wait(0.5)
 
         ## Scene1_SinglePendulum.label
-        periodic_label = Text("Periódico. Predecible.", font_size=28, color=TEAL_A)
+        periodic_label = Text("Periodic. Predictable.", font_size=28, color=TEAL_A)
         periodic_label.next_to(title, DOWN, buff=0.3)
-        self.add_subcaption("Periódico. Predecible. Aburrido.", duration=2)
+        self.add_subcaption("Periodic. Predictable. Boring.", duration=2)
         self.play(Write(periodic_label), run_time=1.2)
         self.wait(1)
 
@@ -123,9 +123,9 @@ class Scene2_DoublePendulumIntro(Scene):
         self.camera.background_color = BLACK
 
         ## Scene2_DoublePendulumIntro.title
-        title = Text("Agreguemos un segundo péndulo", font_size=40, color=WHITE)
+        title = Text("Add a Second Pendulum", font_size=40, color=WHITE)
         title.to_edge(UP, buff=0.4)
-        self.add_subcaption("Ahora añadimos un segundo péndulo debajo del primero.", duration=3)
+        self.add_subcaption("Now attach a second pendulum below the first.", duration=3)
         self.play(FadeIn(title), run_time=1.0)
 
         ## Scene2_DoublePendulumIntro.setup
@@ -157,12 +157,12 @@ class Scene2_DoublePendulumIntro(Scene):
         self.play(Create(rod1), FadeIn(joint_dot), FadeIn(pivot_dot), run_time=1.0)
 
         # Then add second rod and bob
-        self.add_subcaption("Por un momento, todavía se ve ordenado.", duration=3)
+        self.add_subcaption("It still looks orderly... for a moment.", duration=3)
         self.play(Create(rod2), FadeIn(bob2), run_time=1.0)
 
         # Labels
-        label1 = Text("varilla 1", font_size=22, color=GREY_A)
-        label2 = Text("varilla 2", font_size=22, color=GREY_A)
+        label1 = Text("rod 1", font_size=22, color=GREY_A)
+        label2 = Text("rod 2", font_size=22, color=GREY_A)
 
         def update_label1(m):
             jp = joint_pos()
@@ -187,7 +187,7 @@ class Scene2_DoublePendulumIntro(Scene):
         n = 120
         traj = simulate_double_pendulum(state0, n, dt=0.04)
 
-        self.add_subcaption("La complejidad crece con cada oscilación.", duration=3)
+        self.add_subcaption("The complexity grows with every swing.", duration=3)
 
         # Animate through pre-computed frames
         for i in range(0, n, 4):
@@ -210,10 +210,10 @@ class Scene3_ChaosReveal(Scene):
         self.camera.background_color = BLACK
 
         ## Scene3_ChaosReveal.title
-        title = Text("Caos: mismas reglas, destino distinto", font_size=36, color=WHITE)
+        title = Text("Chaos: Same Rules, Different Fate", font_size=36, color=WHITE)
         title.to_edge(UP, buff=0.3)
         self.add_subcaption(
-            "Dos péndulos dobles, con condiciones iniciales casi idénticas.", duration=3
+            "Two double pendulums, nearly identical initial conditions.", duration=3
         )
         self.play(FadeIn(title), run_time=0.8)
 
@@ -270,11 +270,11 @@ class Scene3_ChaosReveal(Scene):
         # Legends
         legend_A = VGroup(
             Dot(radius=0.12, color=TEAL_C),
-            Text("Péndulo A", font_size=22, color=TEAL_C)
+            Text("Pendulum A", font_size=22, color=TEAL_C)
         ).arrange(RIGHT, buff=0.15).to_corner(DL, buff=0.5)
         legend_B = VGroup(
             Dot(radius=0.12, color=GOLD),
-            Text("Péndulo B", font_size=22, color=GOLD)
+            Text("Pendulum B", font_size=22, color=GOLD)
         ).arrange(RIGHT, buff=0.15).next_to(legend_A, RIGHT, buff=0.6)
 
         diff_label = Text("Δθ₁ = 0.001 rad", font_size=20, color=RED_B)
@@ -294,20 +294,20 @@ class Scene3_ChaosReveal(Scene):
         )
 
         ## Scene3_ChaosReveal.phase1: they start together
-        self.add_subcaption("Al principio, se mueven juntos...", duration=3)
+        self.add_subcaption("At first, they move together...", duration=3)
         self.play(frame.animate.set_value(80), run_time=3.0, rate_func=linear)
 
-        ## Scene3_ChaosReveal.phase2 — they diverge
+        ## Scene3_ChaosReveal.phase2: they diverge
         self.add_subcaption(
-            "Luego se separan: completamente, de forma impredecible.", duration=4
+            "Then they diverge, completely, unpredictably.", duration=4
         )
         self.play(frame.animate.set_value(300), run_time=4.5, rate_func=linear)
 
         ## Scene3_ChaosReveal.chaos_label
-        chaos_label = Text("Esto es CAOS", font_size=44, color=RED_B)
+        chaos_label = Text("This is CHAOS", font_size=44, color=RED_B)
         chaos_label.move_to(DOWN * 2.8)
         self.add_subcaption(
-            "Esto es caos: determinismo sin predictibilidad.", duration=3
+            "This is chaos: determinism without predictability.", duration=3
         )
         self.play(Write(chaos_label), run_time=1.2)
         self.wait(1.5)
@@ -327,10 +327,10 @@ class Scene4_PhasePortrait(Scene):
         self.camera.background_color = BLACK
 
         ## Scene4_PhasePortrait.title
-        title = Text("Espacio de fases: donde vive el caos", font_size=36, color=WHITE)
+        title = Text("Phase Space: Where Chaos Lives", font_size=36, color=WHITE)
         title.to_edge(UP, buff=0.3)
         self.add_subcaption(
-            "En el espacio de fases, el movimiento ordenado traza elipses limpias.", duration=3
+            "In phase space, orderly motion traces clean ellipses.", duration=3
         )
         self.play(FadeIn(title), run_time=0.8)
 
@@ -345,10 +345,10 @@ class Scene4_PhasePortrait(Scene):
         )
         axes.move_to(ORIGIN + DOWN * 0.3)
 
-        x_label = Text("θ₂ (ángulo)", font_size=22, color=GREY_A).next_to(
+        x_label = Text("θ₂ (angle)", font_size=22, color=GREY_A).next_to(
             axes.x_axis, DOWN, buff=0.25
         )
-        y_label = Text("ω₂ (velocidad)", font_size=22, color=GREY_A).next_to(
+        y_label = Text("ω₂ (velocity)", font_size=22, color=GREY_A).next_to(
             axes.y_axis, LEFT, buff=0.15
         )
 
@@ -367,10 +367,10 @@ class Scene4_PhasePortrait(Scene):
         ellipse.set_points_as_corners(ellipse_points)
         ellipse.make_smooth()
 
-        simple_label = Text("Péndulo simple: elipse cerrada", font_size=20, color=TEAL_C)
+        simple_label = Text("Simple pendulum: closed ellipse", font_size=20, color=TEAL_C)
         simple_label.to_corner(UL, buff=0.4).shift(DOWN * 1.0)
 
-        self.add_subcaption("Un péndulo simple traza una elipse cerrada y ordenada.", duration=2.5)
+        self.add_subcaption("A simple pendulum traces a neat closed ellipse.", duration=2.5)
         self.play(Create(ellipse), FadeIn(simple_label), run_time=2.5)
         self.wait(0.5)
 
@@ -389,10 +389,10 @@ class Scene4_PhasePortrait(Scene):
         # Build phase path in chunks and draw it progressively
         self.play(FadeOut(ellipse), FadeOut(simple_label), run_time=0.8)
 
-        chaos_label = Text("Péndulo doble: nunca se repite", font_size=20, color=GOLD)
+        chaos_label = Text("Double pendulum: never repeats", font_size=20, color=GOLD)
         chaos_label.to_corner(UL, buff=0.4).shift(DOWN * 1.0)
         self.add_subcaption(
-            "Pero el péndulo doble nunca se repite: vaga para siempre.", duration=4
+            "But the double pendulum never repeats, it wanders forever.", duration=4
         )
         self.play(FadeIn(chaos_label), run_time=0.4)
 
@@ -435,10 +435,10 @@ class Scene5_LyapunovExponent(Scene):
         self.camera.background_color = BLACK
 
         ## Scene5_LyapunovExponent.title
-        title = Text("Midiendo el caos: el exponente de Lyapunov", font_size=34, color=WHITE)
+        title = Text("Measuring Chaos: The Lyapunov Exponent", font_size=34, color=WHITE)
         title.to_edge(UP, buff=0.3)
         self.add_subcaption(
-            "La distancia entre trayectorias crece exponencialmente.", duration=3
+            "The distance between trajectories grows exponentially.", duration=3
         )
         self.play(FadeIn(title), run_time=0.8)
 
@@ -469,10 +469,10 @@ class Scene5_LyapunovExponent(Scene):
             tips=False,
         )
         axes.shift(DOWN * 0.5)
-        x_label = Text("tiempo (s)", font_size=20, color=GREY_A).next_to(
+        x_label = Text("time (s)", font_size=20, color=GREY_A).next_to(
             axes.x_axis, DOWN, buff=0.2
         )
-        y_label = Text("ln(separación)", font_size=20, color=GREY_A).next_to(
+        y_label = Text("ln(separation)", font_size=20, color=GREY_A).next_to(
             axes.y_axis, LEFT, buff=0.15
         )
 
@@ -503,7 +503,7 @@ class Scene5_LyapunovExponent(Scene):
         )
 
         self.add_subcaption(
-            "El exponente de Lyapunov λ > 0 es la firma del caos.", duration=4
+            "The Lyapunov exponent λ > 0 is the signature of chaos.", duration=4
         )
         self.play(Create(sep_curve), run_time=3.0, rate_func=linear)
         self.play(Create(ref_line), run_time=1.0)
@@ -514,11 +514,11 @@ class Scene5_LyapunovExponent(Scene):
         self.play(Write(lambda_eq), run_time=0.8)
 
         forecast_text = Text(
-            "Por qué los pronósticos fallan más allá de ~1 semana", font_size=22, color=GREY_A
+            "Why forecasts fail beyond ~1 week", font_size=22, color=GREY_A
         )
         forecast_text.next_to(lambda_eq, DOWN, buff=0.3)
         self.add_subcaption(
-            "Esto explica por qué la predicción meteorológica a largo plazo es fundamentalmente imposible.",
+            "It explains why long-range weather prediction is fundamentally impossible.",
             duration=3
         )
         self.play(FadeIn(forecast_text), run_time=0.8)
@@ -562,7 +562,7 @@ class Scene6_Conclusion(Scene):
         # Divider line
         divider = DashedLine(UP * 3.5, DOWN * 3.5, color=GREY_D, stroke_width=1.5)
 
-        self.add_subcaption("Las leyes son exactas. El futuro está determinado.", duration=3)
+        self.add_subcaption("The laws are exact. The future is determined.", duration=3)
         self.play(
             Create(left_axes), Create(right_axes),
             Create(divider), run_time=1.2
@@ -592,9 +592,9 @@ class Scene6_Conclusion(Scene):
         chaotic_path.set_points_as_corners(chaotic_pts)
 
         # Labels above each panel
-        label_simple = Text("Péndulo simple", font_size=22, color=TEAL_C)
+        label_simple = Text("Simple pendulum", font_size=22, color=TEAL_C)
         label_simple.next_to(left_axes, UP, buff=0.3)
-        label_chaotic = Text("Péndulo doble", font_size=22, color=GOLD)
+        label_chaotic = Text("Double pendulum", font_size=22, color=GOLD)
         label_chaotic.next_to(right_axes, UP, buff=0.3)
 
         self.play(
@@ -608,12 +608,12 @@ class Scene6_Conclusion(Scene):
 
         ## Scene6_Conclusion.final_text
         self.add_subcaption(
-            "¿Pero la predicción? Imposible más allá de un instante.", duration=3
+            "But prediction? Impossible beyond a heartbeat.", duration=3
         )
         self.wait(2)
 
         final_text = Text(
-            "Determinismo  ≠  Predictibilidad",
+            "Determinism  ≠  Predictability",
             font_size=42,
             color=WHITE,
         )
@@ -621,7 +621,7 @@ class Scene6_Conclusion(Scene):
         final_text.to_edge(DOWN, buff=0.6)
 
         self.add_subcaption(
-            "Determinismo no significa predictibilidad.", duration=3
+            "Determinism does not mean predictability.", duration=3
         )
         self.play(Write(final_text), run_time=2.0)
         self.wait(2.5)

--- a/experiments/manim-skills-comparison/manim-video-affaan/script.py
+++ b/experiments/manim-skills-comparison/manim-video-affaan/script.py
@@ -69,9 +69,9 @@ def attach_updater(b2, pos, tracker, r1, r2, b1):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Scene 1 — Prove: they start identical
+# Scene 1: Prove they start identical
 # Show both pendulums superimposed at the exact same position, then label the
-# 0.5° gap so the viewer can see how small the difference actually is.
+# 0.5 deg gap so the viewer can see how small the difference actually is.
 # ─────────────────────────────────────────────────────────────────────────────
 
 class Scene1_SameStart(Scene):
@@ -84,8 +84,8 @@ class Scene1_SameStart(Scene):
         rA1, rA2, bA1, bA2 = make_pend(posA, BLUE_PEND)
         rB1, rB2, bB1, bB2 = make_pend(posB, RED_PEND)
 
-        # Angle arc showing the 0.5° gap between the two first arms
-        start_angle = np.radians(90) - TH0                # 90° - 120° = -30° (from East)
+        # Angle arc showing the 0.5 deg gap between the two first arms
+        start_angle = np.radians(90) - TH0                # 90 - 120 = -30 deg (from East)
         delta_angle = np.radians(0.5)
         arc = Arc(
             radius=0.9,
@@ -99,7 +99,7 @@ class Scene1_SameStart(Scene):
             .next_to(arc, LEFT, buff=0.1)
 
         thesis = Text(
-            "Mismo inicio: 0.5° de diferencia",
+            "Same start — 0.5° apart",
             font_size=24, color=WHITE,
         ).to_edge(DOWN, buff=0.6)
 
@@ -111,7 +111,7 @@ class Scene1_SameStart(Scene):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Scene 2 — Prove: they diverge
+# Scene 2: Prove they diverge
 # Run both pendulums together. The first ~10s they track closely; then they
 # explode apart. A vertical "sync" indicator fades out as they separate.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -128,14 +128,14 @@ class Scene2_Divergence(Scene):
         trA = TracedPath(bA2.get_center, stroke_color=BLUE_PEND, stroke_width=1.5, dissipating_time=4)
         trB = TracedPath(bB2.get_center, stroke_color=RED_PEND,  stroke_width=1.5, dissipating_time=4)
 
-        # Sync label (fades as they diverge — driven by angular distance)
-        sync_label = Text("en sincronía", font_size=20, color=GREEN_B).to_edge(DOWN, buff=0.6)
+        # Sync label (fades as they diverge, driven by angular distance)
+        sync_label = Text("in sync", font_size=20, color=GREEN_B).to_edge(DOWN, buff=0.6)
 
         f = ValueTracker(0)
         attach_updater(bA2, posA, f, rA1, rA2, bA1)
         attach_updater(bB2, posB, f, rB1, rB2, bB1)
 
-        # Compute frame index where angular distance first exceeds 45°
+        # Compute frame index where angular distance first exceeds 45 deg
         diverge_frame = N - 1
         for i, (a, _, _, _) in enumerate(posA):
             diff = abs(posA[i][0] - posB[i][0])   # x1 difference as proxy
@@ -166,9 +166,9 @@ class Scene2_Divergence(Scene):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Scene 3 — Prove: different outcomes, same physics
+# Scene 3: Prove different outcomes, same physics
 # Show the two full baked trails side-by-side with a minimal annotation.
-# No rods, no motion — just the evidence.
+# No rods, no motion, just the evidence.
 # ─────────────────────────────────────────────────────────────────────────────
 
 class Scene3_Outcomes(Scene):
@@ -187,11 +187,11 @@ class Scene3_Outcomes(Scene):
         trailB = bake(posB, RED_PEND)
 
         title = Text(
-            "Misma física.\nResultados distintos.",
+            "Same physics.\nDifferent outcomes.",
             font_size=28, color=WHITE, line_spacing=1.4,
         )
         sub = Text(
-            "Determinismo no significa predictibilidad.",
+            "Determinism does not mean predictability.",
             font_size=18, color=GRAY_B,
         ).next_to(title, DOWN, buff=0.35)
 

--- a/experiments/manim-skills-comparison/sin-skill/double_pendulum.py
+++ b/experiments/manim-skills-comparison/sin-skill/double_pendulum.py
@@ -71,9 +71,9 @@ class DoublePendulumChaos(Scene):
             all_pos.append(simulate(cfg["th1"], cfg["th2"], N_STEPS, DT, L1, L2))
 
         # --- title ---
-        title = Text("Péndulo doble", font_size=36, color=WHITE).to_edge(UP)
+        title = Text("Double Pendulum", font_size=36, color=WHITE).to_edge(UP)
         subtitle = Text(
-            "Delta theta = 0.5° de diferencia",
+            "Delta theta = 0.5 deg apart",
             font_size=22,
             color=GRAY_B,
         ).next_to(title, DOWN, buff=0.15)
@@ -156,7 +156,7 @@ class DoublePendulumChaos(Scene):
 
         # --- end card ---
         end_text = Text(
-            "Mismas condiciones iniciales,\ntrayectorias completamente distintas.",
+            "Same initial conditions,\ncompletely different trajectories.",
             font_size=24,
             color=WHITE,
             line_spacing=1.3,


### PR DESCRIPTION
## Summary
- Translates remaining on-screen text in the Manim skills comparison experiment from Spanish to English for consistency.

## Test plan
- [x] Reviewed diff for translated strings across all five experiment scripts and README.