### PR TITLE
fix: add build-essential to Docker image for pycairo compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # System dependencies for manim and ffmpeg
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
     ffmpeg \
     libcairo2-dev \
     libpango1.0-dev \


### PR DESCRIPTION
## Summary
- The Docker build has been failing since pycairo dropped prebuilt wheels for this base image: it now needs a C compiler to build from source, and the image only had `libcairo2-dev` headers, not `gcc`.
- Adds `build-essential` to the apt install step.

## Test plan
- [x] CI Docker build run on this PR