### PR TITLE
Fix SSRF in POST /v1/video/exporting

### DIFF
--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -286,14 +286,26 @@ config.frame_width = {frame_width}
 
 @video_rendering_bp.route("/v1/video/exporting", methods=["POST"])
 def export_video():
-    scenes = request.json.get("scenes")
-    title_slug = request.json.get("titleSlug")
+    body, err = get_json_body()
+    if err:
+        return err
+
+    scenes = body.get("scenes")
+    if not isinstance(scenes, list) or not scenes:
+        return jsonify({"error": "'scenes' must be a non-empty array"}), 400
+
+    title_slug = body.get("titleSlug")
     local_filenames = []
 
-    for scene in scenes:
-        video_url = scene["videoUrl"]
-        local_filename = download_video(video_url)
-        local_filenames.append(local_filename)
+    try:
+        for scene in scenes:
+            video_url = scene.get("videoUrl") if isinstance(scene, dict) else None
+            local_filename = download_video(video_url)
+            local_filenames.append(local_filename)
+    except ValueError as e:
+        return jsonify({"error": f"Invalid videoUrl: {e}"}), 400
+    except requests.RequestException as e:
+        return jsonify({"error": f"Failed to download scene video: {e}"}), 400
 
     timestamp = int(time.time())
     safe_slug = re.sub(r'[^a-zA-Z0-9_-]', '', title_slug or 'untitled')
@@ -313,19 +325,30 @@ def export_video():
     try:
         subprocess.run(command_list, check=True)
         public_url = upload_to_azure_storage(
-            merged_filename, f"exported-scene-{title_slug}-{timestamp}"
+            merged_filename, f"exported-scene-{safe_slug}-{timestamp}"
         )
         return jsonify({"status": "Videos merged successfully", "video_url": public_url})
     except subprocess.CalledProcessError:
         return jsonify({"error": "Failed to merge videos"}), 500
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+    finally:
+        for filename in local_filenames:
+            try:
+                os.remove(filename)
+            except OSError:
+                pass
 
 
 def download_video(video_url):
-    local_filename = video_url.split("/")[-1]
-    response = requests.get(video_url)
-    response.raise_for_status()
-    with open(local_filename, 'wb') as f:
-        f.write(response.content)
+    assert_public_http_url(video_url)
+
+    local_filename = os.path.join(os.getcwd(), f"scene-download-{uuid.uuid4().hex}.mp4")
+    with requests.get(video_url, stream=True, timeout=30, allow_redirects=False) as response:
+        if 300 <= response.status_code < 400:
+            raise ValueError("redirects are not allowed for scene video URLs")
+        response.raise_for_status()
+        with open(local_filename, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                f.write(chunk)
     return local_filename

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -14,7 +14,7 @@ from azure.storage.blob import BlobServiceClient
 from flask import Blueprint, Response, jsonify, request
 
 from api.validation import get_json_body, require_string, validate_aspect_ratio, validate_boolean
-from api.video_utils import get_frame_config
+from api.video_utils import assert_public_http_url, get_frame_config
 
 video_rendering_bp = Blueprint("video_rendering", __name__)
 

--- a/api/video_utils.py
+++ b/api/video_utils.py
@@ -1,6 +1,11 @@
 """Shared utilities for video generation and rendering routes."""
 
+import ipaddress
+import socket
 from typing import Tuple
+from urllib.parse import urlparse
+
+ALLOWED_URL_SCHEMES = {"http", "https"}
 
 
 def get_frame_config(aspect_ratio: str) -> Tuple[Tuple[int, int], float]:
@@ -10,3 +15,37 @@ def get_frame_config(aspect_ratio: str) -> Tuple[Tuple[int, int], float]:
     if aspect_ratio == "1:1":
         return (1080, 1080), 8.0
     return (3840, 2160), 14.22
+
+
+def assert_public_http_url(url: str) -> None:
+    """Raise ValueError if *url* is not a safe, public http(s) URL.
+
+    Guards against SSRF: rejects non-http(s) schemes and hostnames that
+    resolve to loopback, private, link-local, or otherwise reserved
+    addresses (e.g. cloud metadata endpoints, internal services).
+    """
+    if not isinstance(url, str) or not url:
+        raise ValueError("URL must be a non-empty string")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ALLOWED_URL_SCHEMES:
+        raise ValueError(f"URL scheme must be one of {sorted(ALLOWED_URL_SCHEMES)}")
+    if not parsed.hostname:
+        raise ValueError("URL must include a hostname")
+
+    try:
+        addrinfo = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"Could not resolve host: {parsed.hostname}") from exc
+
+    for _family, _type, _proto, _canonname, sockaddr in addrinfo:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            raise ValueError(f"URL resolves to a disallowed address: {ip}")


### PR DESCRIPTION
## Summary
- `download_video()` called `requests.get(video_url)` on a fully user-controlled URL with no validation, allowing the server to be made to fetch internal services or cloud metadata endpoints (e.g. `169.254.169.254`) — CWE-918.
- Adds `assert_public_http_url()` in `api/video_utils.py`, which rejects non-http(s) schemes and hostnames that resolve to loopback, private, link-local, or reserved addresses.
- `download_video()` now validates the URL before fetching, disables redirects (an unvalidated redirect target would reintroduce the same bug), adds a request timeout, streams the response instead of buffering it whole, and writes to a random server-chosen filename instead of one derived from the URL.
- `export_video()` now validates the `scenes` payload shape, cleans up downloaded temp files after the ffmpeg merge, and uses the sanitized slug (not the raw `titleSlug`) for the uploaded blob name.

Reported via private disclosure (credit: Saher Boujemline).

## Test plan
- [x] `python3 -m py_compile` on changed files
- [x] Manual check of `assert_public_http_url()` against metadata IP, loopback, `localhost`, `file://`, private RFC1918 IP (all rejected), and a normal `https://` URL (accepted)
- [ ] Manual end-to-end exercise of `/v1/video/exporting` with a real scene video (not run here — no running server in this environment)