### PR TITLE
Fix path traversal via file_class in POST /v1/video/rendering

### DIFF
--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -13,7 +13,13 @@ import requests
 from azure.storage.blob import BlobServiceClient
 from flask import Blueprint, Response, jsonify, request
 
-from api.validation import get_json_body, require_string, validate_aspect_ratio, validate_boolean
+from api.validation import (
+    get_json_body,
+    require_string,
+    validate_aspect_ratio,
+    validate_boolean,
+    validate_identifier,
+)
 from api.video_utils import assert_public_http_url, get_frame_config
 
 video_rendering_bp = Blueprint("video_rendering", __name__)
@@ -75,8 +81,11 @@ def render_video():
     if err:
         return err
 
+    file_class, err = validate_identifier(body, "file_class", default="GenScene")
+    if err:
+        return err
+
     file_name = body.get("file_name")
-    file_class = body.get("file_class")
     user_id = body.get("user_id") or str(uuid.uuid4())
     project_name = body.get("project_name")
     iteration = body.get("iteration")

--- a/api/validation.py
+++ b/api/validation.py
@@ -1,8 +1,11 @@
 """Request body validation helpers for the Flask API routes."""
 
+import re
+
 from flask import jsonify, request
 
 VALID_ASPECT_RATIOS = {"16:9", "9:16", "1:1"}
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def get_json_body():
@@ -42,6 +45,27 @@ def validate_aspect_ratio(body, default="16:9"):
     if value not in VALID_ASPECT_RATIOS:
         return None, (
             jsonify({"error": f"'aspect_ratio' must be one of: {', '.join(sorted(VALID_ASPECT_RATIOS))}"}),
+            400,
+        )
+    return value, None
+
+
+def validate_identifier(body, field, default):
+    """Validate an optional field that must be a bare Python identifier.
+
+    Used for values (e.g. a Manim scene class name) that get interpolated
+    into file paths or CLI arguments, where anything other than a plain
+    identifier (letters, digits, underscore, not starting with a digit)
+    could enable path traversal or argument injection.
+
+    Returns ``(value, None)`` on success or ``(None, error_response)`` if invalid.
+    """
+    value = body.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str) or not IDENTIFIER_RE.match(value):
+        return None, (
+            jsonify({"error": f"'{field}' must be a valid identifier (letters, digits, underscore only)"}),
             400,
         )
     return value, None


### PR DESCRIPTION
## Summary
- `file_class` came straight from the request body with no validation and was interpolated into a filesystem path (`f"{file_class}.mp4"`) used to locate the rendered output, then moved into the public web directory via `shutil.move` — CWE-22 / CWE-200.
- A value like `../../../../tmp/secret` could cause the handler to pick up and relocate (removing from its original location) an arbitrary `.mp4`-suffixed file reachable by the process, then serve it at a public URL.
- Adds `validate_identifier()` in `api/validation.py`: requires `file_class` to be a bare identifier (letters, digits, underscore, not starting with a digit) — which is what a real Manim scene class name looks like anyway. Defaults to `"GenScene"` when omitted, matching prior fallback behavior.

Reported via private disclosure (credit: Saher Boujemline).

## Test plan
- [x] `python3 -m py_compile` on changed files
- [x] `validate_identifier()` exercised inside a Flask app context against a normal class name, a traversal payload, a name with a space, a name starting with a digit, and an omitted field — all behave as expected
- [ ] Manual end-to-end exercise of `/v1/video/rendering` (not run here — no running server in this environment)