### PR TITLE
Add API key authentication for the Flask API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -6,6 +6,7 @@ from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
+from .auth import require_api_key
 from .routes.chat_generation import chat_generation_bp
 from .routes.code_generation import code_generation_bp
 from .routes.health import health_bp
@@ -42,6 +43,8 @@ def create_app():
     limiter.limit("60 per minute")(code_generation_bp)
 
     CORS(app)
+
+    app.before_request(require_api_key)
 
     @app.errorhandler(429)
     def ratelimit_handler(e):

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,32 @@
+"""Simple API key authentication for the Flask API."""
+
+import hmac
+import os
+
+from flask import jsonify, request
+
+_EXEMPT_PATHS = {"/", "/openapi.yaml", "/health", "/v1/health"}
+
+
+def require_api_key():
+    """Flask before_request hook enforcing an API key on protected routes.
+
+    Reads API_KEY from the environment on every call (not at import time)
+    so tests and tools can toggle it without reloading the app. If API_KEY
+    is unset, authentication is not enforced, which keeps local development
+    working without extra setup. Set API_KEY in any deployment reachable
+    from the public internet: unauthenticated access lets any caller run
+    arbitrary code through the rendering endpoints.
+    """
+    api_key = os.getenv("API_KEY")
+    if not api_key:
+        return None
+
+    if request.path in _EXEMPT_PATHS or request.path.startswith("/public/"):
+        return None
+
+    provided = request.headers.get("X-API-Key", "")
+    if not hmac.compare_digest(provided, api_key):
+        return jsonify({"error": "Invalid or missing API key"}), 401
+
+    return None

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -38,7 +38,10 @@ ANTHROPIC_API_KEY=your_anthropic_key
 GEMINI_API_KEY=your_gemini_key
 USE_LOCAL_STORAGE=true
 BASE_URL=https://your-api-domain.example
+API_KEY=a_long_random_secret
 ```
+
+`API_KEY` protects every route except `/`, `/openapi.yaml`, `/health`, `/v1/health`, and served files under `/public/...`. Callers must send it back as the `X-API-Key` header. If `API_KEY` is unset, no authentication is enforced, which is only appropriate for local development: the rendering endpoints execute arbitrary submitted code, so any public deployment must set `API_KEY`.
 
 If you use Azure Blob Storage for rendered videos, set:
 
@@ -77,6 +80,7 @@ Then test code generation:
 ```bash
 curl -X POST https://your-render-service.onrender.com/v1/code/generation \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
   -d '{"prompt":"Create a Manim animation with a blue circle expanding from the center."}'
 ```
 
@@ -85,6 +89,7 @@ And test rendering:
 ```bash
 curl -X POST https://your-render-service.onrender.com/v1/video/rendering \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
   -d '{
     "code": "class DrawCircle(Scene):\n    def construct(self):\n        circle = Circle(color=BLUE)\n        self.play(Create(circle))",
     "file_class": "DrawCircle",
@@ -113,6 +118,7 @@ docker run --rm -p 8080:8080 \
   -e GEMINI_API_KEY="$GEMINI_API_KEY" \
   -e USE_LOCAL_STORAGE=true \
   -e BASE_URL="http://localhost:8080" \
+  -e API_KEY="$API_KEY" \
   generative-manim-api
 ```
 
@@ -175,4 +181,4 @@ That avoids web request timeouts and lets you scale render workers separately fr
 
 ## Security
 
-Generated Manim code is Python code. Treat rendering as untrusted code execution unless all prompts and code come from trusted users. For public deployments, isolate render workers, restrict network access where possible, add authentication, rate-limit requests, and set per-job time and memory limits.
+Generated Manim code is Python code. Treat rendering as untrusted code execution unless all prompts and code come from trusted users. For public deployments, isolate render workers, restrict network access where possible, set `API_KEY` to require authentication, rate-limit requests (already enabled by default), and set per-job time and memory limits.


### PR DESCRIPTION
## Summary
- The API had no authentication mechanism anywhere: `api/__init__.py` only wired up `flask_limiter` (per-IP rate limiting) and permissive CORS. Every route, including `/v1/video/rendering` (which executes user-submitted Python via manim), was reachable by any caller who could hit the server.
- Adds `api/auth.py` with `require_api_key()`, a `before_request` hook that checks an `X-API-Key` header against the `API_KEY` env var using `hmac.compare_digest` (constant-time comparison, avoids timing side-channels).
- Exempts `/`, `/openapi.yaml`, `/health`, `/v1/health`, and served files under `/public/...` so health checks and shared video links keep working without a key.
- If `API_KEY` is unset, auth is not enforced — keeps local dev/testing working out of the box. Any public deployment should set it. This is documented in `docs/cloud-deployment.md` along with updated curl examples showing the header.

This closes the "fully public, no auth" gap flagged in a private security disclosure (credit: Saher Boujemline) alongside the RCE/SSRF/path-traversal fixes in #85 and #86. It does not by itself prevent RCE from a caller who *has* a valid key — that's addressed separately via Docker hardening (non-root user) in a follow-up PR, with fuller sandboxing/isolation left as a larger future project per the existing `docs/cloud-deployment.md` security section.

## Test plan
- [x] `python3 -m py_compile` on changed files
- [x] Flask test client: with `API_KEY` set, `/health` returns 200 with no header, `/v1/video/rendering` returns 401 with no/wrong key, `/v1/models` returns 200 with the correct `X-API-Key` header
- [x] Flask test client: with `API_KEY` unset, `/v1/models` returns 200 with no header (backward-compatible dev mode)
- [ ] Manual end-to-end exercise of protected routes against a running deployed instance (not run here — no running server in this environment)