### PR TITLE
Run the container as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,14 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY api/ api/
 
+RUN useradd --create-home --uid 1000 appuser \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
 ENV FLASK_APP=api.run
 ENV FLASK_ENV=production
+ENV HOME=/home/appuser
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- The Dockerfile had no `USER` directive, so `gunicorn` — and the `manim` subprocess it spawns to execute user-submitted code — ran as root by default. A private security disclosure (credit: Saher Boujemline) demonstrated this concretely: the unauthenticated RCE in `/v1/video/rendering` (now closed by #87's auth requirement, though defense-in-depth still matters) produced `uid=0(root) gid=0(root)`.
- Adds a dedicated non-root `appuser` (uid 1000, with a home directory), `chown -R`'s `/app` to it, and switches to it via `USER appuser` before the final `CMD`. Also sets `HOME=/home/appuser` explicitly for anything (manim/matplotlib/LaTeX caches, etc.) that looks up the user's home directory.
- This limits the blast radius of any future code-execution bug in the render path: a compromise no longer hands an attacker root inside the container.

## Test plan
- [ ] **Not verified in this environment** — no Docker daemon available in this sandbox, so I could not `docker build` / `docker run` this image end-to-end. Please build and smoke-test before/after merging:
  ```bash
  docker build -t generative-manim-api .
  docker run --rm -p 8080:8080 generative-manim-api
  docker exec <container> id   # should show uid=1000(appuser), not uid=0(root)
  curl -X POST http://localhost:8080/v1/video/rendering -H "Content-Type: application/json" -d '{"code":"class DrawCircle(Scene):\n    def construct(self):\n        self.play(Create(Circle()))","file_class":"DrawCircle"}'
  ```
  Confirm rendering still succeeds and the output file gets written/moved correctly (the app writes into `api/routes/` and `api/public/`, both under `/app` which is `chown`'d to `appuser`).