### PR TITLE
Add GPT-5.6 series (Sol/Terra/Luna) to the OpenAI model registry

### DIFF
--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -24,7 +24,7 @@ chat_generation_bp = Blueprint("chat_generation", __name__)
 FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1"
 
 _ENGINE_DEFAULTS = {
-    "openai": "gpt-4o",
+    "openai": "gpt-5.6-terra",
     "anthropic": "claude-sonnet-4-6",
     "deepseek": "r1",
     "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
@@ -33,7 +33,7 @@ _ENGINE_DEFAULTS = {
 }
 
 _VALID_MODELS = {
-    "openai": ["gpt-4o", "o1-mini"],
+    "openai": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-4o", "o1-mini"],
     "anthropic": [
         "claude-sonnet-4-6",
         "claude-opus-4-7",
@@ -229,7 +229,7 @@ def generate_code_chat():
 
 # What the user can do?
 
-The user can create a new project, add scenes, and generate the video. You can help the user to generate the video by creating the code for the scenes. The user can add custom rules for you, can select a different aspect ratio, and can change the model (the models are: OpenAI GPT-4o, and Anthropic Claude 3.5 Sonnet).
+The user can create a new project, add scenes, and generate the video. You can help the user to generate the video by creating the code for the scenes. The user can add custom rules for you, can select a different aspect ratio, and can change the model (the models are: OpenAI GPT-5.6, and Anthropic Claude Sonnet).
 
 # Project
 
@@ -663,7 +663,7 @@ Rules:
                 for attempt in range(max_retries):
                     try:
                         stream = client.chat.completions.create(
-                            model="gpt-4o",
+                            model=model,
                             messages=messages,
                             stream=True,
                             functions=animo_functions["openai"],

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -13,7 +13,7 @@ code_generation_bp = Blueprint('code_generation', __name__)
 
 
 ENGINE_DEFAULTS = {
-    "openai": "gpt-4o",
+    "openai": "gpt-5.6-terra",
     "anthropic": "claude-sonnet-4-6",
     "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
     "gemini": "gemini-2.5-flash",

--- a/api/routes/models.py
+++ b/api/routes/models.py
@@ -9,9 +9,12 @@ models_bp = Blueprint("models", __name__)
 _ENGINES = {
     "openai": {
         "env_var": "OPENAI_API_KEY",
-        "default": "gpt-4o",
+        "default": "gpt-5.6-terra",
         "models": [
-            {"id": "gpt-4o", "description": "GPT-4o: OpenAI's latest multimodal model"},
+            {"id": "gpt-5.6-sol", "description": "GPT-5.6 Sol: frontier model for complex professional work"},
+            {"id": "gpt-5.6-terra", "description": "GPT-5.6 Terra: balances intelligence and cost"},
+            {"id": "gpt-5.6-luna", "description": "GPT-5.6 Luna: fastest, most cost-efficient tier"},
+            {"id": "gpt-4o", "description": "GPT-4o: OpenAI's multimodal model"},
             {"id": "o1-mini", "description": "o1-mini: compact reasoning model"},
         ],
     },

--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -16,7 +16,7 @@ from api.video_utils import get_frame_config
 video_generation_bp = Blueprint('video_generation', __name__)
 
 
-def generate_manim_code(prompt, engine="openai", model="gpt-4o"):
+def generate_manim_code(prompt, engine="openai", model="gpt-5.6-terra"):
     if model.startswith("claude-"):
         client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
         messages = [{"role": "user", "content": prompt}]
@@ -71,7 +71,7 @@ def generate_video():
             return err
 
         engine = body.get("engine", "openai")
-        model = body.get("model", "gpt-4o")
+        model = body.get("model", "gpt-5.6-terra")
         user_id = body.get("user_id") or str(uuid.uuid4())
         project_name = body.get("project_name", "untitled")
         iteration = body.get("iteration", 1)

--- a/tests/test_chat_generation.py
+++ b/tests/test_chat_generation.py
@@ -94,7 +94,7 @@ class TestChatGenerationEngineValidation:
 
 
 class TestChatGenerationModelDefaults:
-    def test_openai_default_model_is_gpt4o(self, client, monkeypatch):
+    def test_openai_default_model_is_gpt_5_6_terra(self, client, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         captured = {}
         with mock.patch("openai.OpenAI") as mock_openai:
@@ -103,7 +103,7 @@ class TestChatGenerationModelDefaults:
                 return iter([])
             mock_openai.return_value.chat.completions.create.side_effect = capture
             client.post("/v1/chat/generation", json={"prompt": "test", "engine": "openai"})
-        assert captured.get("model") == "gpt-4o"
+        assert captured.get("model") == "gpt-5.6-terra"
 
     def test_anthropic_default_model_is_claude_sonnet_4_6(self, client, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -56,7 +56,7 @@ class TestCodeGenerationOpenAI:
         assert resp.status_code == 200
         assert "code" in resp.get_json()
 
-    def test_uses_default_model_gpt4o(self, client, monkeypatch):
+    def test_uses_default_model_gpt_5_6_terra(self, client, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         captured = {}
         with mock.patch("api.routes.code_generation.get_openai_compatible_client") as mock_client:
@@ -65,7 +65,7 @@ class TestCodeGenerationOpenAI:
                 return _make_openai_response("code")
             mock_client.return_value.chat.completions.create.side_effect = capture
             client.post("/v1/code/generation", json={"prompt": "test", "engine": "openai"})
-        assert captured.get("model") == "gpt-4o"
+        assert captured.get("model") == "gpt-5.6-terra"
 
     def test_custom_model_forwarded(self, client, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")


### PR DESCRIPTION
## Summary
- Adds OpenAI's newest GPT-5.6 tier (Sol/Terra/Luna) to the `/v1/models` registry, alongside the existing GPT-4o and o1-mini entries
- Switches the OpenAI default across chat generation, code generation, and video generation from `gpt-4o` to `gpt-5.6-terra` (balanced capability/cost tier)
- Fixes a bug in the chat generation streaming fallback path that ignored the resolved model and always called `gpt-4o` regardless of engine default or caller-supplied model

## Test plan
- [x] `pytest tests/` — 176 passed
- [x] Verified `/v1/models` returns the new GPT-5.6 entries with `gpt-5.6-terra` as default
- [x] Verified chat/code/video generation forward the new default model to the OpenAI client