### PR TITLE
Add Claude 5 series (Fable 5, Opus 4.8, Sonnet 5) to the Anthropic model registry

### DIFF
--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -25,7 +25,7 @@ FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1"
 
 _ENGINE_DEFAULTS = {
     "openai": "gpt-4o",
-    "anthropic": "claude-sonnet-4-6",
+    "anthropic": "claude-sonnet-5",
     "deepseek": "r1",
     "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
     "litellm": "openai/gpt-4o",
@@ -35,6 +35,9 @@ _ENGINE_DEFAULTS = {
 _VALID_MODELS = {
     "openai": ["gpt-4o", "o1-mini"],
     "anthropic": [
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-opus-4-7",
         "claude-haiku-4-5-20251001",
@@ -229,7 +232,7 @@ def generate_code_chat():
 
 # What the user can do?
 
-The user can create a new project, add scenes, and generate the video. You can help the user to generate the video by creating the code for the scenes. The user can add custom rules for you, can select a different aspect ratio, and can change the model (the models are: OpenAI GPT-4o, and Anthropic Claude 3.5 Sonnet).
+The user can create a new project, add scenes, and generate the video. You can help the user to generate the video by creating the code for the scenes. The user can add custom rules for you, can select a different aspect ratio, and can change the model (the models are: OpenAI GPT-4o, and Anthropic Claude Sonnet 5).
 
 # Project
 

--- a/api/routes/code_generation.py
+++ b/api/routes/code_generation.py
@@ -14,7 +14,7 @@ code_generation_bp = Blueprint('code_generation', __name__)
 
 ENGINE_DEFAULTS = {
     "openai": "gpt-4o",
-    "anthropic": "claude-sonnet-4-6",
+    "anthropic": "claude-sonnet-5",
     "featherless": "Qwen/Qwen2.5-Coder-7B-Instruct",
     "gemini": "gemini-2.5-flash",
     "litellm": "openai/gpt-4o",

--- a/api/routes/models.py
+++ b/api/routes/models.py
@@ -17,10 +17,13 @@ _ENGINES = {
     },
     "anthropic": {
         "env_var": "ANTHROPIC_API_KEY",
-        "default": "claude-sonnet-4-6",
+        "default": "claude-sonnet-5",
         "models": [
-            {"id": "claude-sonnet-4-6", "description": "Claude Sonnet 4.6: balanced speed and quality"},
-            {"id": "claude-opus-4-7", "description": "Claude Opus 4.7: highest capability"},
+            {"id": "claude-fable-5", "description": "Claude Fable 5: most capable model, for the most demanding reasoning"},
+            {"id": "claude-opus-4-8", "description": "Claude Opus 4.8: highest capability, state of the art on long-horizon agentic work"},
+            {"id": "claude-sonnet-5", "description": "Claude Sonnet 5: best combination of speed and intelligence"},
+            {"id": "claude-sonnet-4-6", "description": "Claude Sonnet 4.6: previous-generation balanced model"},
+            {"id": "claude-opus-4-7", "description": "Claude Opus 4.7: previous-generation Opus"},
             {"id": "claude-haiku-4-5-20251001", "description": "Claude Haiku 4.5: fastest and most compact"},
             {"id": "claude-3-5-sonnet-20241022", "description": "Claude 3.5 Sonnet (legacy)"},
         ],

--- a/tests/test_chat_generation.py
+++ b/tests/test_chat_generation.py
@@ -105,7 +105,7 @@ class TestChatGenerationModelDefaults:
             client.post("/v1/chat/generation", json={"prompt": "test", "engine": "openai"})
         assert captured.get("model") == "gpt-4o"
 
-    def test_anthropic_default_model_is_claude_sonnet_4_6(self, client, monkeypatch):
+    def test_anthropic_default_model_is_claude_sonnet_5(self, client, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         captured = {}
         with mock.patch("anthropic.Anthropic") as mock_anthropic:
@@ -114,7 +114,7 @@ class TestChatGenerationModelDefaults:
                 return iter([])
             mock_anthropic.return_value.messages.create.side_effect = capture
             client.post("/v1/chat/generation", json={"prompt": "test", "engine": "anthropic"})
-        assert captured.get("model") == "claude-sonnet-4-6"
+        assert captured.get("model") == "claude-sonnet-5"
 
 
 class TestChatGenerationPromptMessages:

--- a/tests/test_code_generation.py
+++ b/tests/test_code_generation.py
@@ -118,7 +118,7 @@ class TestCodeGenerationAnthropic:
         data = resp.get_json()
         assert data["code"] == "from manim import *"
 
-    def test_uses_default_claude_sonnet_4_6(self, client, monkeypatch):
+    def test_uses_default_claude_sonnet_5(self, client, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         captured = {}
         with mock.patch("anthropic.Anthropic") as mock_anthropic:
@@ -127,7 +127,7 @@ class TestCodeGenerationAnthropic:
                 return _make_anthropic_response("code")
             mock_anthropic.return_value.messages.create.side_effect = capture
             client.post("/v1/code/generation", json={"prompt": "test", "engine": "anthropic"})
-        assert captured.get("model") == "claude-sonnet-4-6"
+        assert captured.get("model") == "claude-sonnet-5"
 
     def test_claude_opus_4_7_accepted(self, client, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,15 +42,18 @@ class TestModelsEndpoint:
         openai_entry = next(e for e in data["engines"] if e["engine"] == "openai")
         assert openai_entry["configured"] is True
 
-    def test_anthropic_default_is_claude_sonnet_4_6(self, client):
+    def test_anthropic_default_is_claude_sonnet_5(self, client):
         data = client.get("/v1/models").get_json()
         anthropic = next(e for e in data["engines"] if e["engine"] == "anthropic")
-        assert anthropic["default"] == "claude-sonnet-4-6"
+        assert anthropic["default"] == "claude-sonnet-5"
 
-    def test_anthropic_models_include_claude_4(self, client):
+    def test_anthropic_models_include_claude_5_and_4(self, client):
         data = client.get("/v1/models").get_json()
         anthropic = next(e for e in data["engines"] if e["engine"] == "anthropic")
         model_ids = [m["id"] for m in anthropic["models"]]
+        assert "claude-sonnet-5" in model_ids
+        assert "claude-opus-4-8" in model_ids
+        assert "claude-fable-5" in model_ids
         assert "claude-sonnet-4-6" in model_ids
         assert "claude-opus-4-7" in model_ids
 


### PR DESCRIPTION
## Summary
- Adds Anthropic's newest generation to the `/v1/models` registry: `claude-fable-5` (most capable, demanding reasoning), `claude-opus-4-8` (highest capability), and `claude-sonnet-5` (best speed/intelligence balance), alongside the existing 4.6/4.7 and legacy entries
- Switches the Anthropic default across chat generation and code generation from `claude-sonnet-4-6` to `claude-sonnet-5`

## Test plan
- [x] `pytest tests/` — 176 passed
- [x] Verified `/v1/models` returns the new Claude 5 entries with `claude-sonnet-5` as default
- [x] Verified chat/code generation forward the new default model to the Anthropic client