### PR TITLE
Sanitize video output filenames against path traversal

### DIFF
--- a/api/routes/video_generation.py
+++ b/api/routes/video_generation.py
@@ -10,7 +10,7 @@ from openai import OpenAI
 from api.errors import gateway_timeout, internal_error
 from api.llm_providers import generate_gemini_content
 from api.prompts.system import MANIM_CODE_GENERATION_PROMPT
-from api.validation import get_json_body, require_string, validate_aspect_ratio
+from api.validation import get_json_body, require_string, safe_filename_component, validate_aspect_ratio
 from api.video_utils import get_frame_config
 
 video_generation_bp = Blueprint('video_generation', __name__)
@@ -90,9 +90,9 @@ def generate_video():
 
         engine = body.get("engine", "openai")
         model = body.get("model", "gpt-5.6-terra")
-        user_id = body.get("user_id") or str(uuid.uuid4())
-        project_name = body.get("project_name", "untitled")
-        iteration = body.get("iteration", 1)
+        user_id = safe_filename_component(body.get("user_id"), str(uuid.uuid4()))
+        project_name = safe_filename_component(body.get("project_name"), "untitled")
+        iteration = safe_filename_component(body.get("iteration"), "1")
 
         try:
             code = generate_manim_code(prompt, engine, model)

--- a/api/routes/video_rendering.py
+++ b/api/routes/video_rendering.py
@@ -16,6 +16,7 @@ from flask import Blueprint, Response, jsonify, request
 from api.validation import (
     get_json_body,
     require_string,
+    safe_filename_component,
     validate_aspect_ratio,
     validate_boolean,
     validate_identifier,
@@ -86,9 +87,9 @@ def render_video():
         return err
 
     file_name = body.get("file_name")
-    user_id = body.get("user_id") or str(uuid.uuid4())
-    project_name = body.get("project_name")
-    iteration = body.get("iteration")
+    user_id = safe_filename_component(body.get("user_id"), str(uuid.uuid4()))
+    project_name = safe_filename_component(body.get("project_name"), "untitled")
+    iteration = safe_filename_component(body.get("iteration"), "1")
 
     video_storage_file_name = f"video-{user_id}-{project_name}-{iteration}"
 

--- a/api/validation.py
+++ b/api/validation.py
@@ -71,6 +71,19 @@ def validate_identifier(body, field, default):
     return value, None
 
 
+def safe_filename_component(value, default):
+    """Sanitize a value for safe use as part of an on-disk filename.
+
+    Strips everything except letters, digits, underscore and hyphen so the
+    result cannot contain path separators or '..' traversal sequences, then
+    falls back to *default* if nothing safe is left (e.g. the input was
+    empty, ``None``, or entirely made of unsafe characters).
+    """
+    text = "" if value is None else str(value)
+    cleaned = re.sub(r"[^A-Za-z0-9_-]", "", text)
+    return cleaned or default
+
+
 def validate_boolean(body, field, default=False):
     """Validate an optional boolean field.
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -127,6 +127,40 @@ class TestValidateAspectRatio:
         assert "aspect_ratio" in resp.get_json()["error"]
 
 
+class TestSafeFilenameComponent:
+    def test_plain_value_is_kept(self, client):
+        from api.validation import safe_filename_component
+        with client.application.test_request_context("/"):
+            value = safe_filename_component("my-project_1", "default")
+        assert value == "my-project_1"
+
+    def test_path_traversal_sequence_is_stripped(self, client):
+        from api.validation import safe_filename_component
+        with client.application.test_request_context("/"):
+            value = safe_filename_component("../../etc/passwd", "default")
+        assert "/" not in value
+        assert ".." not in value
+        assert value == "etcpasswd"
+
+    def test_none_falls_back_to_default(self, client):
+        from api.validation import safe_filename_component
+        with client.application.test_request_context("/"):
+            value = safe_filename_component(None, "default")
+        assert value == "default"
+
+    def test_only_unsafe_chars_falls_back_to_default(self, client):
+        from api.validation import safe_filename_component
+        with client.application.test_request_context("/"):
+            value = safe_filename_component("../../../", "default")
+        assert value == "default"
+
+    def test_non_string_value_is_stringified(self, client):
+        from api.validation import safe_filename_component
+        with client.application.test_request_context("/"):
+            value = safe_filename_component(3, "default")
+        assert value == "3"
+
+
 class TestValidateBoolean:
     def test_true_accepted(self, client):
         from api.validation import validate_boolean

--- a/tests/test_video_generation.py
+++ b/tests/test_video_generation.py
@@ -141,6 +141,39 @@ class TestVideoGenerationGemini:
         assert resp.status_code == 200
 
 
+class TestVideoGenerationFilenameSafety:
+    def test_path_traversal_in_project_name_is_sanitized(self, client, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        msg = mock.MagicMock()
+        msg.content = VALID_MANIM_CODE
+        choice = mock.MagicMock()
+        choice.message = msg
+        openai_resp = mock.MagicMock()
+        openai_resp.choices = [choice]
+
+        subprocess_result = mock.MagicMock()
+        subprocess_result.returncode = 0
+
+        with mock.patch("api.routes.video_generation.OpenAI") as mock_openai:
+            mock_openai.return_value.chat.completions.create.return_value = openai_resp
+            with mock.patch("api.routes.video_generation.subprocess.run", return_value=subprocess_result):
+                with mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("shutil.move") as mock_move:
+                        resp = client.post("/v1/video/generation", json={
+                            "prompt": "draw a circle",
+                            "engine": "openai",
+                            "user_id": "../../etc",
+                            "project_name": "../../../secrets",
+                            "iteration": "1/../2",
+                        })
+
+        assert resp.status_code == 200
+        destination = mock_move.call_args[0][1]
+        assert ".." not in destination
+        assert os.path.basename(destination) == "video-etc-secrets-12.mp4"
+
+
 class TestVideoGenerationAspectRatio:
     def test_default_aspect_ratio_is_16_9(self, client, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")

--- a/tests/test_video_rendering.py
+++ b/tests/test_video_rendering.py
@@ -128,6 +128,34 @@ class TestVideoRenderingFailure:
         assert resp.status_code == 500
 
 
+class TestVideoRenderingFilenameSafety:
+    def test_path_traversal_in_project_name_is_sanitized(self, client, monkeypatch):
+        monkeypatch.setenv("USE_LOCAL_STORAGE", "true")
+        popen_mock = _make_popen_mock(returncode=0)
+
+        with mock.patch("api.routes.video_rendering.subprocess.Popen", return_value=popen_mock):
+            with mock.patch("os.path.exists", return_value=True):
+                with mock.patch("os.listdir", return_value=["GenScene.mp4"]):
+                    with mock.patch("api.routes.video_rendering.move_to_public_folder",
+                                    return_value="http://localhost/video.mp4") as mock_move:
+                        with mock.patch("builtins.open", mock.mock_open()):
+                            with mock.patch("os.remove"):
+                                resp = client.post("/v1/video/rendering", json={
+                                    "code": VALID_CODE,
+                                    "file_name": "GenScene",
+                                    "file_class": "GenScene",
+                                    "user_id": "../../etc",
+                                    "project_name": "../../../secrets",
+                                    "iteration": "1/../2",
+                                })
+
+        assert resp.status_code == 200
+        video_storage_file_name = mock_move.call_args[0][1]
+        assert ".." not in video_storage_file_name
+        assert "/" not in video_storage_file_name
+        assert video_storage_file_name == "video-etc-secrets-12"
+
+
 class TestVideoRenderingAspectRatio:
     def _run_with_captured_write(self, client, monkeypatch, aspect_ratio):
         monkeypatch.setenv("USE_LOCAL_STORAGE", "true")


### PR DESCRIPTION
## Summary

- Adds `safe_filename_component()` in `api/validation.py`, which strips everything except letters, digits, `_`, and `-` from a value, falling back to a default when nothing safe is left.
- Applies it to `user_id`, `project_name`, and `iteration` in both `api/routes/video_rendering.py` and `api/routes/video_generation.py` before they're used to build the on-disk output filename.

## Why

Both routes built `video_storage_file_name = f"video-{user_id}-{project_name}-{iteration}"` directly from unvalidated request fields, then passed it into `shutil.move(...)` when writing the rendered video to `public/`. Since `os.path.join`/`shutil.move` don't sanitize `..` segments, a `project_name` like `../../../etc/passwd` could move the rendered file outside of `public/`, overwriting arbitrary files reachable by the process.

`api/validation.py` already had `validate_identifier()` for exactly this class of bug, applied to `file_class`, but not to `user_id`/`project_name`/`iteration`. Those fields need to allow more than a bare identifier (e.g. spaces in a project name), so this adds a looser sibling helper rather than reusing `validate_identifier()`.

## Test plan

- Added `TestSafeFilenameComponent` in `tests/test_validation.py` covering the sanitizer directly.
- Added a regression test in each of `tests/test_video_rendering.py` and `tests/test_video_generation.py` that sends `project_name`/`user_id`/`iteration` containing `../` and asserts the resulting filename has no path separators or `..`.
- `ruff check api/ tests/` and `pytest tests/` both pass (191 passed).

Closes #91