### PR TITLE
Validate class_name and drop shell=True in preview generation

### DIFF
--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -17,7 +17,7 @@ from PIL import Image
 
 from api.llm_providers import generate_gemini_content_stream
 from api.prompts.manimDocs import manimDocs
-from api.validation import get_json_body
+from api.validation import get_json_body, is_valid_identifier
 
 chat_generation_bp = Blueprint("chat_generation", __name__)
 
@@ -133,6 +133,12 @@ def manage_conversation_images(messages, new_images_count, engine):
 
 def _generate_manim_preview(code: str, class_name: str) -> str:
     """Run Manim in PNG mode and return a JSON string with base64-encoded frames."""
+    if not is_valid_identifier(class_name):
+        return json.dumps({
+            "error": "ERROR. 'class_name' must be a valid identifier (letters, digits, underscore only).",
+            "images": [],
+        })
+
     current_dir = os.path.dirname(os.path.abspath(__file__))
     api_dir = os.path.dirname(current_dir)
 
@@ -145,12 +151,12 @@ def _generate_manim_preview(code: str, class_name: str) -> str:
     with open(file_path, "w") as f:
         f.write(preview_code)
 
-    command = (
-        f"manim {file_path} {class_name} "
-        f"--format=png --media_dir {temp_dir} --custom_folders -pql --disable_caching"
-    )
+    command = [
+        "manim", file_path, class_name,
+        "--format=png", "--media_dir", temp_dir, "--custom_folders", "-pql", "--disable_caching",
+    ]
     try:
-        subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True)
 
         previews_dir = os.path.join(api_dir, "public", "previews")
         os.makedirs(previews_dir, exist_ok=True)

--- a/api/validation.py
+++ b/api/validation.py
@@ -50,20 +50,26 @@ def validate_aspect_ratio(body, default="16:9"):
     return value, None
 
 
+def is_valid_identifier(value):
+    """Return True if *value* is a bare Python identifier.
+
+    Used to guard values (e.g. a Manim scene class name) that get
+    interpolated into file paths or CLI arguments, where anything other
+    than a plain identifier (letters, digits, underscore, not starting
+    with a digit) could enable path traversal or argument injection.
+    """
+    return isinstance(value, str) and bool(IDENTIFIER_RE.match(value))
+
+
 def validate_identifier(body, field, default):
     """Validate an optional field that must be a bare Python identifier.
-
-    Used for values (e.g. a Manim scene class name) that get interpolated
-    into file paths or CLI arguments, where anything other than a plain
-    identifier (letters, digits, underscore, not starting with a digit)
-    could enable path traversal or argument injection.
 
     Returns ``(value, None)`` on success or ``(None, error_response)`` if invalid.
     """
     value = body.get(field, default)
     if value is None:
         value = default
-    if not isinstance(value, str) or not IDENTIFIER_RE.match(value):
+    if not is_valid_identifier(value):
         return None, (
             jsonify({"error": f"'{field}' must be a valid identifier (letters, digits, underscore only)"}),
             400,

--- a/tests/test_chat_generation.py
+++ b/tests/test_chat_generation.py
@@ -1,8 +1,42 @@
 """Tests for /v1/chat/generation route validation and engine routing."""
 
+import json
 from unittest import mock
 
 import pytest
+
+from api.routes.chat_generation import _generate_manim_preview
+
+
+class TestGenerateManimPreview:
+    def test_rejects_class_name_with_shell_metacharacters(self):
+        result = json.loads(_generate_manim_preview("class GenScene(Scene): pass", "Foo; rm -rf /"))
+        assert "error" in result
+        assert result["images"] == []
+
+    def test_rejects_class_name_with_path_traversal(self):
+        result = json.loads(_generate_manim_preview("class GenScene(Scene): pass", "../../etc/passwd"))
+        assert "error" in result
+
+    def test_invalid_class_name_never_reaches_subprocess(self):
+        with mock.patch("api.routes.chat_generation.subprocess.run") as mock_run:
+            _generate_manim_preview("class GenScene(Scene): pass", "$(whoami)")
+        mock_run.assert_not_called()
+
+    def test_valid_class_name_runs_subprocess_without_shell(self):
+        subprocess_result = mock.MagicMock()
+        subprocess_result.returncode = 0
+
+        with mock.patch("api.routes.chat_generation.subprocess.run", return_value=subprocess_result) as mock_run:
+            with mock.patch("os.listdir", return_value=[]):
+                with mock.patch("builtins.open", mock.mock_open()):
+                    _generate_manim_preview("class GenScene(Scene): pass", "GenScene")
+
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        assert isinstance(args[0], list)
+        assert "GenScene" in args[0]
+        assert kwargs.get("shell") is not True
 
 
 class TestChatGenerationEngineValidation:


### PR DESCRIPTION
## Summary

- `_generate_manim_preview()` in `api/routes/chat_generation.py` now rejects `class_name` values that aren't a bare identifier (letters, digits, underscore) before doing anything with the filesystem or subprocess.
- Replaces the `shell=True` string command with a list-form `subprocess.run(...)` call, matching the pattern already used in `video_rendering.py` / `video_generation.py`.
- Adds `is_valid_identifier()` to `api/validation.py`, extracted from the existing `validate_identifier()` (which now uses it internally) so it can be reused outside the Flask request-body validation flow.

## Why

`class_name` comes from an LLM tool-call argument (`args['class_name']` / `tool_call.get('class_name', '')`) and was interpolated directly into a shell command string:

```python
command = (
    f"manim {file_path} {class_name} "
    f"--format=png --media_dir {temp_dir} --custom_folders -pql --disable_caching"
)
subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
```

With `shell=True`, any shell metacharacters in `class_name` are interpreted by the shell rather than passed as a literal argument. The same value was also used unsanitized in a file path (`temp_dir/{class_name}.py`), so it doubled as a path traversal vector.

## Test plan

- Added `TestGenerateManimPreview` in `tests/test_chat_generation.py`: rejects shell-metacharacter and path-traversal `class_name` values before subprocess is ever called, and verifies valid calls use a list-form command with `shell` not set to `True`.
- `ruff check api/ tests/` and `pytest tests/` both pass (188 passed).

Closes #92