### PR TITLE
Apply the conversation image cap regardless of engine

### DIFF
--- a/api/routes/chat_generation.py
+++ b/api/routes/chat_generation.py
@@ -113,10 +113,7 @@ def count_images_in_conversation(messages):
                 image_message_indices.append(i)
     return total_images, image_message_indices
 
-def manage_conversation_images(messages, new_images_count, engine):
-    if engine != "openai":
-        return new_images_count
-
+def manage_conversation_images(messages, new_images_count):
     MAX_IMAGES = 50
     current_total, image_indices = count_images_in_conversation(messages)
 
@@ -793,7 +790,7 @@ Rules:
                                 ]
                             }
 
-                            available_slots = manage_conversation_images(messages, len(result_json["images"]), engine)
+                            available_slots = manage_conversation_images(messages, len(result_json["images"]))
                             total_frames = len(result_json["images"])
                             frame_interval = max(1, total_frames // available_slots)
                             selected_frames = result_json["images"][::frame_interval][:available_slots]

--- a/tests/test_image_management.py
+++ b/tests/test_image_management.py
@@ -66,43 +66,33 @@ class TestCountImagesInConversation:
 
 
 class TestManageConversationImages:
-    def test_non_openai_engine_returns_count_unchanged(self):
+    def test_within_limit_returns_count(self):
         msgs = [_image_msg(5)]
-        result = manage_conversation_images(msgs, 10, "anthropic")
-        assert result == 10
-
-    def test_non_openai_engine_does_not_remove_messages(self):
-        msgs = [_image_msg(5)]
-        original_len = len(msgs)
-        manage_conversation_images(msgs, 100, "gemini")
-        assert len(msgs) == original_len
-
-    def test_openai_within_limit_returns_count(self):
-        msgs = [_image_msg(5)]
-        result = manage_conversation_images(msgs, 10, "openai")
+        result = manage_conversation_images(msgs, 10)
         assert result == min(50 - 5, 10)
 
-    def test_openai_at_limit_triggers_eviction(self):
+    def test_at_limit_triggers_eviction(self):
         msgs = [_image_msg(40)]
-        result = manage_conversation_images(msgs, 15, "openai")
+        result = manage_conversation_images(msgs, 15)
         assert result <= 50
 
-    def test_openai_over_limit_evicts_oldest(self):
+    def test_over_limit_evicts_oldest(self):
         msgs = [_image_msg(30), _image_msg(25)]
         original_len = len(msgs)
-        manage_conversation_images(msgs, 5, "openai")
+        manage_conversation_images(msgs, 5)
         assert len(msgs) < original_len
 
-    def test_openai_no_existing_images_returns_new_count(self):
+    def test_no_existing_images_returns_new_count(self):
         msgs = [_text_msg("user", "hello")]
-        result = manage_conversation_images(msgs, 20, "openai")
+        result = manage_conversation_images(msgs, 20)
         assert result == 20
 
-    def test_featherless_returns_count_unchanged(self):
-        msgs = []
-        result = manage_conversation_images(msgs, 7, "featherless")
-        assert result == 7
+    def test_cap_applies_regardless_of_conversation_size(self):
+        msgs = [_image_msg(5)]
+        original_len = len(msgs)
+        manage_conversation_images(msgs, 100)
+        assert len(msgs) <= original_len
 
-    def test_litellm_returns_count_unchanged(self):
-        result = manage_conversation_images([], 3, "litellm")
-        assert result == 3
+    def test_empty_conversation_returns_new_count(self):
+        result = manage_conversation_images([], 7)
+        assert result == 7


### PR DESCRIPTION
## Summary

`manage_conversation_images()` in `api/routes/chat_generation.py` special-cased on `engine != "openai"` to skip its 50-image eviction logic entirely. This function is only called from one place in the code (the OpenAI-compatible `get_preview` tool-call loop), but that same code path is shared by any engine that doesn't have its own dedicated branch, currently `deepseek`, since it falls through the `litellm`/`featherless`/`moonshot`/`gemini`/`anthropic` checks into the final `else:`. So in practice, `engine == "deepseek"` conversations never had old preview frames evicted, and could grow the image list without bound.

## Fix

Removed the `engine != "openai"` early return so the cap is always applied, and dropped the now-unused `engine` parameter from `manage_conversation_images()` (updating its single call site accordingly).

## Test plan

- Updated `tests/test_image_management.py`: the old tests asserted the cap was skipped for `anthropic`/`gemini`/`featherless`/`litellm` (testing the bug itself, since none of those engines actually call this function); replaced with tests asserting the cap always applies regardless of conversation size.
- `ruff check api/ tests/` and `pytest tests/` both pass (182 passed).

Closes #93