### PR TITLE
Sync README model table with api/routes/models.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,25 @@ Key improvements over Generative Manim:
 
 | Name                          | Description                                                               | Engine                     | Phase |
 | ----------------------------- | ------------------------------------------------------------------------- | -------------------------- | ----- |
-| GM GPT-5.5                    | OpenAI's newest frontier model for complex professional and coding work    | gpt-5.5                    | ✅    |
+| GM GPT-5.6 Sol                | OpenAI's frontier model for complex professional and coding work          | gpt-5.6-sol                | ✅    |
+| GM GPT-5.6 Terra              | Default OpenAI model, balances intelligence and cost                     | gpt-5.6-terra              | ✅    |
+| GM GPT-5.6 Luna               | Fastest, most cost-efficient OpenAI tier                                  | gpt-5.6-luna                | ✅    |
 | GM GPT-4o                     | Latest GPT model from OpenAI powered by a custom System Prompt            | GPT-4o                     | ✅    |
+| GM o1-mini                    | Compact OpenAI reasoning model                                            | o1-mini                    | ✅    |
 | GM GPT-3.5 Fine Tuned         | First Fine-tuned model of GPT-3.5                                         | GPT-3.5                    | ✅    |
 | GM GPT-3.5 Physics Fine Tuned | Fine-tuned GPT-3.5 model trained to generate Physics animations           | GPT-3.5                    | ✅    |
 | GM Claude Sonnet              | Claude Sonnet 3 model from Sonnet adapted with our custom System Prompt   | claude-3-sonnet-20240229   | ✅    |
 | GM Claude Sonnet 3.5          | Claude Sonnet 3.5 model from Sonnet adapted with our custom System Prompt | claude-3-5-sonnet-20241022 | ✅    |
-| GM Claude Sonnet 4.6          | Claude Sonnet 4.6 (default Anthropic model) adapted with our custom System Prompt | claude-sonnet-4-6 | ✅    |
+| GM Claude Sonnet 4.6          | Claude Sonnet 4.6 adapted with our custom System Prompt                  | claude-sonnet-4-6          | ✅    |
+| GM Claude Sonnet 5            | Default Anthropic model, best combination of speed and intelligence      | claude-sonnet-5            | ✅    |
 | GM Claude Opus 4.7            | Claude Opus 4.7 for highest-quality Anthropic generation                  | claude-opus-4-7            | ✅    |
+| GM Claude Opus 4.8            | Highest capability, state of the art on long-horizon agentic work        | claude-opus-4-8            | ✅    |
 | GM Claude Haiku 4.5           | Claude Haiku 4.5 for fast, lightweight Anthropic generation               | claude-haiku-4-5-20251001  | ✅    |
+| GM Claude Fable 5             | Most capable Anthropic model, for the most demanding reasoning           | claude-fable-5             | ✅    |
 | GM Featherless Open Models    | OpenAI-compatible access to hosted open-weight models via Featherless     | Qwen, DeepSeek, CodeLlama, etc. | ✅ |
+| GM LiteLLM Passthrough        | Accepts any model string supported by LiteLLM (e.g. `openai/gpt-4o`)     | litellm                    | ✅    |
 | GM Gemini 2.5 Flash           | Google's Gemini 2.5 Flash accessed via google-genai SDK                  | gemini-2.5-flash           | ✅    |
+| GM Gemini 2.5 Pro             | Google's Gemini 2.5 Pro accessed via google-genai SDK                    | gemini-2.5-pro             | ✅    |
 | GM Gemini 3 Flash             | Google's Gemini 3 Flash preview accessed via google-genai SDK            | gemini-3-flash-preview     | ✅    |
 | GM Kimi K3                    | Moonshot AI's flagship model, 1M-token context with always-on thinking mode | kimi-k3                 | ✅    |
 | GM Kimi K2.7 Code             | Moonshot AI's coding-specialized agentic model                           | kimi-k2.7-code             | ✅    |

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,15 +60,28 @@
 
 | 名称 (Name)                   | 描述 (Description)                                           | 引擎 (Engine)              | 阶段 (Phase) |
 | ----------------------------- | ------------------------------------------------------------ | -------------------------- | ------------ |
-| GM GPT-5.5                    | OpenAI 用于复杂专业及编码工作的最新前沿模型                  | gpt-5.5                    | ✅            |
+| GM GPT-5.6 Sol                 | OpenAI 用于复杂专业及编码工作的前沿模型                      | gpt-5.6-sol                 | ✅            |
+| GM GPT-5.6 Terra               | 默认 OpenAI 模型，兼顾智能与成本                            | gpt-5.6-terra               | ✅            |
+| GM GPT-5.6 Luna                | 速度最快、成本最低的 OpenAI 档位                            | gpt-5.6-luna                | ✅            |
 | GM GPT-4o                     | 由自定义系统提示词（System Prompt）驱动的 OpenAI 最新 GPT 模型 | GPT-4o                     | ✅            |
+| GM o1-mini                    | 精简型 OpenAI 推理模型                                      | o1-mini                    | ✅            |
 | GM GPT-3.5 Fine Tuned         | 首个 GPT-3.5 微调模型                                        | GPT-3.5                    | ✅            |
 | GM GPT-3.5 Physics Fine Tuned | 经训练用于生成物理动画的 GPT-3.5 微调模型                    | GPT-3.5                    | ✅            |
 | GM Claude Sonnet              | 经我们自定义系统提示词适配的 Claude Sonnet 3 模型            | claude-3-sonnet-20240229   | ✅            |
-| GM Claude Sonnet 3.5          | 经我们自定义系统提示词适配的 Claude Sonnet 3.5 模型          | claude-3-5-sonnet-20240620 | ✅            |
+| GM Claude Sonnet 3.5          | 经我们自定义系统提示词适配的 Claude Sonnet 3.5 模型          | claude-3-5-sonnet-20241022 | ✅            |
+| GM Claude Sonnet 4.6          | 经我们自定义系统提示词适配的 Claude Sonnet 4.6 模型          | claude-sonnet-4-6          | ✅            |
+| GM Claude Sonnet 5            | 默认 Anthropic 模型，兼顾速度与智能                          | claude-sonnet-5            | ✅            |
+| GM Claude Opus 4.7            | Claude Opus 4.7，用于最高质量的 Anthropic 生成               | claude-opus-4-7            | ✅            |
+| GM Claude Opus 4.8            | 能力最强，长周期智能体任务的最新水平                          | claude-opus-4-8            | ✅            |
+| GM Claude Haiku 4.5           | Claude Haiku 4.5，快速轻量的 Anthropic 生成                  | claude-haiku-4-5-20251001  | ✅            |
+| GM Claude Fable 5             | 能力最强的 Anthropic 模型，用于最具挑战性的推理任务           | claude-fable-5             | ✅            |
 | GM Featherless Open Models    | 通过 Featherless 以 OpenAI 兼容的方式访问的托管开源权重模型 | Qwen, DeepSeek, CodeLlama 等 | ✅          |
+| GM LiteLLM Passthrough        | 接受 LiteLLM 支持的任意模型字符串（例如 `openai/gpt-4o`）     | litellm                    | ✅            |
 | GM Gemini 2.5 Flash           | 通过 google-genai SDK 访问的 Google Gemini 2.5 Flash 模型   | gemini-2.5-flash           | ✅            |
+| GM Gemini 2.5 Pro             | 通过 google-genai SDK 访问的 Google Gemini 2.5 Pro 模型     | gemini-2.5-pro             | ✅            |
 | GM Gemini 3 Flash             | 通过 google-genai SDK 访问的 Google Gemini 3 Flash 预览版   | gemini-3-flash-preview     | ✅            |
+| GM Kimi K3                    | Moonshot AI 的旗舰模型，100 万 token 上下文，常驻思考模式    | kimi-k3                    | ✅            |
+| GM Kimi K2.7 Code             | Moonshot AI 面向编码的智能体专用模型                         | kimi-k2.7-code             | ✅            |
 | GM Qwen 2.5 Coder 7B          | 使用 SFT + DPO + GRPO 流程进行微调的开源模型                | Qwen2.5-Coder-7B-Instruct  | 🚧            |
 | GM DeepSeek Coder V2 Lite     | 使用 SFT + DPO + GRPO 流程进行微调的开源模型                | DeepSeek-Coder-V2-Lite     | 🚧            |
 | GM CodeLlama 7B               | 使用 SFT + DPO + GRPO 流程进行微调的开源模型                | CodeLlama-7b-Instruct      | 🚧            |

--- a/README_DE.md
+++ b/README_DE.md
@@ -59,15 +59,28 @@ Es begann als Prototyp einer Web-App, die [GPT-4](https://openai.com/research/gp
 
 | Name                          | Beschreibung                                                                     | Engine                     | Phase |
 | ----------------------------- | -------------------------------------------------------------------------------- | -------------------------- | ----- |
-| GM GPT-5.5                    | OpenAIs neuestes Frontier-Modell für komplexe professionelle und Coding-Arbeit   | gpt-5.5                    | ✅    |
+| GM GPT-5.6 Sol                 | OpenAIs Frontier-Modell für komplexe professionelle und Coding-Arbeit            | gpt-5.6-sol                 | ✅    |
+| GM GPT-5.6 Terra               | Standardmodell von OpenAI, Balance aus Intelligenz und Kosten                    | gpt-5.6-terra               | ✅    |
+| GM GPT-5.6 Luna                | Schnellste, kosteneffizienteste OpenAI-Stufe                                     | gpt-5.6-luna                | ✅    |
 | GM GPT-4o                     | Neuestes GPT-Modell von OpenAI mit einem benutzerdefinierten System Prompt       | GPT-4o                     | ✅    |
+| GM o1-mini                    | Kompaktes Reasoning-Modell von OpenAI                                            | o1-mini                     | ✅    |
 | GM GPT-3.5 Fine Tuned         | Erstes Fine-tuned-Modell von GPT-3.5                                            | GPT-3.5                    | ✅    |
 | GM GPT-3.5 Physics Fine Tuned | Fine-tuned GPT-3.5-Modell, trainiert zur Generierung von Physik-Animationen      | GPT-3.5                    | ✅    |
 | GM Claude Sonnet              | Claude Sonnet 3-Modell, angepasst mit unserem benutzerdefinierten System Prompt  | claude-3-sonnet-20240229   | ✅    |
-| GM Claude Sonnet 3.5          | Claude Sonnet 3.5-Modell, angepasst mit unserem benutzerdefinierten System Prompt | claude-3-5-sonnet-20240620 | ✅    |
+| GM Claude Sonnet 3.5          | Claude Sonnet 3.5-Modell, angepasst mit unserem benutzerdefinierten System Prompt | claude-3-5-sonnet-20241022 | ✅    |
+| GM Claude Sonnet 4.6          | Claude Sonnet 4.6-Modell, angepasst mit unserem benutzerdefinierten System Prompt | claude-sonnet-4-6         | ✅    |
+| GM Claude Sonnet 5            | Standardmodell von Anthropic, beste Kombination aus Geschwindigkeit und Intelligenz | claude-sonnet-5          | ✅    |
+| GM Claude Opus 4.7            | Claude Opus 4.7 für Anthropic-Generierung höchster Qualität                     | claude-opus-4-7            | ✅    |
+| GM Claude Opus 4.8            | Höchste Fähigkeit, Stand der Technik bei langfristigen agentischen Aufgaben      | claude-opus-4-8            | ✅    |
+| GM Claude Haiku 4.5           | Claude Haiku 4.5 für schnelle, leichtgewichtige Anthropic-Generierung            | claude-haiku-4-5-20251001  | ✅    |
+| GM Claude Fable 5             | Fähigstes Anthropic-Modell, für die anspruchsvollsten Reasoning-Aufgaben         | claude-fable-5             | ✅    |
 | GM Featherless Open Models    | OpenAI-kompatibler Zugang zu gehosteten Open-Weight-Modellen via Featherless     | Qwen, DeepSeek, CodeLlama, etc. | ✅ |
+| GM LiteLLM Passthrough        | Akzeptiert jeden von LiteLLM unterstützten Modell-String (z. B. `openai/gpt-4o`) | litellm                    | ✅    |
 | GM Gemini 2.5 Flash           | Googles Gemini 2.5 Flash, aufgerufen via google-genai SDK                       | gemini-2.5-flash           | ✅    |
+| GM Gemini 2.5 Pro             | Googles Gemini 2.5 Pro, aufgerufen via google-genai SDK                         | gemini-2.5-pro             | ✅    |
 | GM Gemini 3 Flash             | Googles Gemini 3 Flash Preview, aufgerufen via google-genai SDK                 | gemini-3-flash-preview     | ✅    |
+| GM Kimi K3                    | Moonshot AIs Flaggschiffmodell, 1M-Token-Kontext mit permanentem Denkmodus      | kimi-k3                    | ✅    |
+| GM Kimi K2.7 Code             | Auf Coding spezialisiertes agentisches Modell von Moonshot AI                   | kimi-k2.7-code              | ✅    |
 | GM Qwen 2.5 Coder 7B          | Open-Source-Modell, feinabgestimmt mit SFT + DPO + GRPO-Pipeline               | Qwen2.5-Coder-7B-Instruct | 🚧    |
 | GM DeepSeek Coder V2 Lite     | Open-Source-Modell, feinabgestimmt mit SFT + DPO + GRPO-Pipeline               | DeepSeek-Coder-V2-Lite     | 🚧    |
 | GM CodeLlama 7B               | Open-Source-Modell, feinabgestimmt mit SFT + DPO + GRPO-Pipeline               | CodeLlama-7b-Instruct      | 🚧    |

--- a/README_ES.md
+++ b/README_ES.md
@@ -59,15 +59,28 @@ Los **modelos** son el núcleo de Generative Manim. Un modelo es una forma de co
 
 | Nombre                        | Descripción                                                                       | Motor                      | Fase |
 | ----------------------------- | --------------------------------------------------------------------------------- | -------------------------- | ----- |
-| GM GPT-5.5                    | El modelo de frontera más reciente de OpenAI para trabajo profesional y de código  | gpt-5.5                    | ✅    |
+| GM GPT-5.6 Sol                 | Modelo de frontera de OpenAI para trabajo profesional y de código complejo        | gpt-5.6-sol                 | ✅    |
+| GM GPT-5.6 Terra               | Modelo predeterminado de OpenAI, equilibra inteligencia y costo                  | gpt-5.6-terra               | ✅    |
+| GM GPT-5.6 Luna                | Nivel de OpenAI más rápido y económico                                          | gpt-5.6-luna                | ✅    |
 | GM GPT-4o                     | Último modelo GPT de OpenAI impulsado por un System Prompt personalizado           | GPT-4o                     | ✅    |
+| GM o1-mini                    | Modelo de razonamiento compacto de OpenAI                                        | o1-mini                     | ✅    |
 | GM GPT-3.5 Fine Tuned         | Primer modelo ajustado fino de GPT-3.5                                            | GPT-3.5                    | ✅    |
-| GM GPT-3.5 Physics Fine Tuned | Modelo GPT-3.5 ajustado fino para generar animaciones de Física                   | GPT-3.5                    | ✅    |
+| GM GPT-3.5 Physics Fine Tuned | Modelo GPT-3.5 ajustado fino para generar animaciones de física                   | GPT-3.5                    | ✅    |
 | GM Claude Sonnet              | Modelo Claude Sonnet 3 adaptado con nuestro System Prompt personalizado           | claude-3-sonnet-20240229   | ✅    |
-| GM Claude Sonnet 3.5          | Modelo Claude Sonnet 3.5 adaptado con nuestro System Prompt personalizado         | claude-3-5-sonnet-20240620 | ✅    |
+| GM Claude Sonnet 3.5          | Modelo Claude Sonnet 3.5 adaptado con nuestro System Prompt personalizado         | claude-3-5-sonnet-20241022 | ✅    |
+| GM Claude Sonnet 4.6          | Modelo Claude Sonnet 4.6 adaptado con nuestro System Prompt personalizado        | claude-sonnet-4-6          | ✅    |
+| GM Claude Sonnet 5            | Modelo predeterminado de Anthropic, mejor combinación de velocidad e inteligencia | claude-sonnet-5            | ✅    |
+| GM Claude Opus 4.7            | Claude Opus 4.7 para generación de la más alta calidad en Anthropic              | claude-opus-4-7            | ✅    |
+| GM Claude Opus 4.8            | Máxima capacidad, estado del arte en trabajo agéntico de largo horizonte          | claude-opus-4-8            | ✅    |
+| GM Claude Haiku 4.5           | Claude Haiku 4.5 para generación rápida y ligera en Anthropic                     | claude-haiku-4-5-20251001  | ✅    |
+| GM Claude Fable 5             | Modelo más capaz de Anthropic, para el razonamiento más exigente                 | claude-fable-5             | ✅    |
 | GM Featherless Open Models    | Acceso compatible con OpenAI a modelos de código abierto alojados via Featherless | Qwen, DeepSeek, CodeLlama, etc. | ✅ |
+| GM LiteLLM Passthrough        | Acepta cualquier cadena de modelo compatible con LiteLLM (por ejemplo, `openai/gpt-4o`) | litellm              | ✅    |
 | GM Gemini 2.5 Flash           | Gemini 2.5 Flash de Google accedido via google-genai SDK                         | gemini-2.5-flash           | ✅    |
+| GM Gemini 2.5 Pro             | Gemini 2.5 Pro de Google accedido via google-genai SDK                           | gemini-2.5-pro             | ✅    |
 | GM Gemini 3 Flash             | Vista previa de Gemini 3 Flash de Google accedido via google-genai SDK            | gemini-3-flash-preview     | ✅    |
+| GM Kimi K3                    | Modelo insignia de Moonshot AI, contexto de 1M de tokens con razonamiento continuo | kimi-k3                  | ✅    |
+| GM Kimi K2.7 Code             | Modelo agéntico de Moonshot AI especializado en código                          | kimi-k2.7-code              | ✅    |
 | GM Qwen 2.5 Coder 7B          | Modelo de código abierto ajustado fino con pipeline SFT + DPO + GRPO             | Qwen2.5-Coder-7B-Instruct | 🚧    |
 | GM DeepSeek Coder V2 Lite     | Modelo de código abierto ajustado fino con pipeline SFT + DPO + GRPO             | DeepSeek-Coder-V2-Lite     | 🚧    |
 | GM CodeLlama 7B               | Modelo de código abierto ajustado fino con pipeline SFT + DPO + GRPO             | CodeLlama-7b-Instruct      | 🚧    |

--- a/README_KO.md
+++ b/README_KO.md
@@ -59,15 +59,28 @@
 
 | 이름                          | 설명                                                                          | 엔진                       | 단계 |
 | ----------------------------- | ----------------------------------------------------------------------------- | -------------------------- | ----- |
-| GM GPT-5.5                    | 복잡한 전문적 및 코딩 작업을 위한 OpenAI의 최신 프론티어 모델                  | gpt-5.5                    | ✅    |
+| GM GPT-5.6 Sol                 | 복잡한 전문적 및 코딩 작업을 위한 OpenAI의 프론티어 모델                       | gpt-5.6-sol                 | ✅    |
+| GM GPT-5.6 Terra               | 지능과 비용의 균형을 맞춘 OpenAI 기본 모델                                    | gpt-5.6-terra               | ✅    |
+| GM GPT-5.6 Luna                | 가장 빠르고 비용 효율적인 OpenAI 등급                                        | gpt-5.6-luna                | ✅    |
 | GM GPT-4o                     | 커스텀 System Prompt로 구동되는 OpenAI의 최신 GPT 모델                         | GPT-4o                     | ✅    |
+| GM o1-mini                    | 경량 OpenAI 추론 모델                                                        | o1-mini                     | ✅    |
 | GM GPT-3.5 Fine Tuned         | 첫 번째 GPT-3.5 파인튜닝 모델                                                 | GPT-3.5                    | ✅    |
 | GM GPT-3.5 Physics Fine Tuned | 물리 애니메이션 생성을 위해 훈련된 파인튜닝 GPT-3.5 모델                       | GPT-3.5                    | ✅    |
 | GM Claude Sonnet              | 커스텀 System Prompt로 적용된 Claude Sonnet 3 모델                            | claude-3-sonnet-20240229   | ✅    |
-| GM Claude Sonnet 3.5          | 커스텀 System Prompt로 적용된 Claude Sonnet 3.5 모델                          | claude-3-5-sonnet-20240620 | ✅    |
+| GM Claude Sonnet 3.5          | 커스텀 System Prompt로 적용된 Claude Sonnet 3.5 모델                          | claude-3-5-sonnet-20241022 | ✅    |
+| GM Claude Sonnet 4.6          | 커스텀 System Prompt로 적용된 Claude Sonnet 4.6 모델                          | claude-sonnet-4-6          | ✅    |
+| GM Claude Sonnet 5            | 속도와 지능의 균형이 가장 뛰어난 Anthropic 기본 모델                          | claude-sonnet-5            | ✅    |
+| GM Claude Opus 4.7            | 최고 품질의 Anthropic 생성을 위한 Claude Opus 4.7                             | claude-opus-4-7            | ✅    |
+| GM Claude Opus 4.8            | 최고 수준의 성능, 장기 에이전틱 작업에서 최첨단 성능                          | claude-opus-4-8            | ✅    |
+| GM Claude Haiku 4.5           | 빠르고 가벼운 Anthropic 생성을 위한 Claude Haiku 4.5                          | claude-haiku-4-5-20251001  | ✅    |
+| GM Claude Fable 5             | 가장 까다로운 추론 작업을 위한 Anthropic의 가장 강력한 모델                    | claude-fable-5             | ✅    |
 | GM Featherless Open Models    | Featherless를 통해 호스팅된 오픈 웨이트 모델에 대한 OpenAI 호환 접근          | Qwen, DeepSeek, CodeLlama, 등 | ✅ |
+| GM LiteLLM Passthrough        | LiteLLM이 지원하는 모든 모델 문자열을 허용 (예: `openai/gpt-4o`)              | litellm                    | ✅    |
 | GM Gemini 2.5 Flash           | google-genai SDK를 통해 접근하는 Google의 Gemini 2.5 Flash                    | gemini-2.5-flash           | ✅    |
+| GM Gemini 2.5 Pro             | google-genai SDK를 통해 접근하는 Google의 Gemini 2.5 Pro                      | gemini-2.5-pro             | ✅    |
 | GM Gemini 3 Flash             | google-genai SDK를 통해 접근하는 Google의 Gemini 3 Flash 프리뷰               | gemini-3-flash-preview     | ✅    |
+| GM Kimi K3                    | 100만 토큰 컨텍스트와 상시 사고 모드를 갖춘 Moonshot AI의 대표 모델           | kimi-k3                     | ✅    |
+| GM Kimi K2.7 Code             | 코딩에 특화된 Moonshot AI의 에이전틱 모델                                    | kimi-k2.7-code              | ✅    |
 | GM Qwen 2.5 Coder 7B          | SFT + DPO + GRPO 파이프라인으로 파인튜닝된 오픈소스 모델                      | Qwen2.5-Coder-7B-Instruct | 🚧    |
 | GM DeepSeek Coder V2 Lite     | SFT + DPO + GRPO 파이프라인으로 파인튜닝된 오픈소스 모델                      | DeepSeek-Coder-V2-Lite     | 🚧    |
 | GM CodeLlama 7B               | SFT + DPO + GRPO 파이프라인으로 파인튜닝된 오픈소스 모델                      | CodeLlama-7b-Instruct      | 🚧    |


### PR DESCRIPTION
## Summary

Updates the "Models" table in `README.md` (and its `README_CN.md`, `README_ES.md`, `README_DE.md`, `README_KO.md` translations) to match what `api/routes/models.py`'s `_ENGINES` dict actually serves via `/v1/models`.

## Changes

- Replaced the stale `GM GPT-5.5` row (engine string `gpt-5.5`, which doesn't exist anywhere in the codebase) with the current OpenAI lineup: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and `o1-mini`.
- Added the missing Anthropic models: `claude-fable-5`, `claude-sonnet-5` (the actual default), `claude-opus-4-8`.
- Added `gemini-2.5-pro`.
- Added a row for the `litellm` passthrough engine, which wasn't documented anywhere in the table.
- Fixed a stale `claude-3-5-sonnet-20240620` id in the translated READMEs; the model actually served is `claude-3-5-sonnet-20241022` (already correct in the English README).
- Kept the historical GPT-3.5 / Claude Sonnet 3 rows and the `gemini-3-flash-preview` row as-is, since those are still accurate (the latter is a real alias handled in `api/llm_providers.py`, just not listed in `models.py`'s registry).

## Test plan

- `pytest tests/` and `ruff check api/ tests/` both pass (184 passed) — this PR is docs-only.
- Verified all five tables have a consistent column count per row.

Closes #94